### PR TITLE
Add ELBv2 support, public IP registration, AWS metadata population

### DIFF
--- a/aws/elb.go
+++ b/aws/elb.go
@@ -1,83 +1,174 @@
 package aws
 
 import (
-    "github.com/aws/aws-sdk-go/service/elbv2"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/aws"
-    "fmt"
+	"fmt"
+	"log"
+	"strconv"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+
+	"github.com/gliderlabs/registrator/bridge"
+	eureka "github.com/hudl/fargo"
 )
 
 // LBInfo represents a ELBv2 endpoint
 type LBInfo struct {
-    DNSName string
-    Port int64
+	DNSName string
+	Port    int64
 }
 
 // GetELBV2ForContainer returns an LBInfo struct with the load balancer DNS name and listener port for a given instanceId and port
-// if an error occurs, or the target is not found, an empty LBInfo is returned.
+// if an error occurs, or the target is not found, an empty LBInfo is returned. Return the DNS:port pair as an identifier to put in the container's registration metadata
+// Pass it the instanceID for the docker host, and the the host port to lookup the associated ELB.
 func GetELBV2ForContainer(instanceID string, port int64) LBInfo {
 
-    var lb []*string
-    var lbPort *int64
-    info := LBInfo{}
+	var lb []*string
+	var lbPort *int64
+	info := LBInfo{}
 
-    sess, err := session.NewSession()
-    if err != nil {
-        fmt.Println("failed to create session,", err)
-        return info 
-    }
-    svc := elbv2.New(sess)
+	sess, err := session.NewSession()
+	if err != nil {
+		fmt.Println("failed to create session,", err)
+		return info
+	}
+	svc := elbv2.New(sess)
 
-    // Loop through target group pages and check for port and instanceID
-    //
-    params := &elbv2.DescribeTargetGroupsInput{
-        PageSize: aws.Int64(10),
+	// Loop through target group pages and check for port and instanceID
+	//
+	params := &elbv2.DescribeTargetGroupsInput{
+		PageSize: awssdk.Int64(10),
+	}
+	tgs, err := svc.DescribeTargetGroups(params)
 
-    }
-    tgs, err := svc.DescribeTargetGroups(params)
+	if err != nil {
+		// Print the error, cast err to awserr.Error to get the Code and
+		// Message from an error.
+		fmt.Println(err.Error())
+		return info
+	}
 
-    if err != nil {
-        // Print the error, cast err to awserr.Error to get the Code and
-        // Message from an error.
-        fmt.Println(err.Error())
-        return info
-    }
+	// Check each target group for a matching port and instanceID
+	// We assume that there is only one LB for the target group (though the data structure allows more)
+	for _, tg := range tgs.TargetGroups {
+		params4 := &elbv2.DescribeTargetHealthInput{
+			TargetGroupArn: awssdk.String(*tg.TargetGroupArn),
+		}
+		tarH, err := svc.DescribeTargetHealth(params4)
 
-    // Check each target group for a matching port and instanceID
-    // We assume that there is only one LB for the target group (though the data structure allows more)
-    for _, tg := range tgs.TargetGroups {
-        params4 := &elbv2.DescribeTargetHealthInput{
-            TargetGroupArn: aws.String(*tg.TargetGroupArn),
-        }
-        tarH, err := svc.DescribeTargetHealth(params4)
+		for _, thd := range tarH.TargetHealthDescriptions {
+			if *thd.Target.Port == port && *thd.Target.Id == instanceID {
+				lb = tg.LoadBalancerArns
+				lbPort = tg.Port
+			}
 
-        for _, thd := range tarH.TargetHealthDescriptions {
-            if *thd.Target.Port == port && *thd.Target.Id == instanceID {
-                lb = tg.LoadBalancerArns
-                lbPort = tg.Port
-            }
+		}
+		if err != nil {
+			fmt.Println(err.Error())
+			return info
+		}
+		fmt.Printf("LB is: %v\n", *lb[0])
+		fmt.Printf("LB Port is: %v\n", *lbPort)
+	}
 
-        }
-        if err != nil {
-            fmt.Println(err.Error())
-            return info
-        }
-        fmt.Printf("LB is: %v\n", *lb[0])
-        fmt.Printf("LB Port is: %v\n", *lbPort)
-    }
+	params2 := &elbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: lb,
+	}
+	lbData, err := svc.DescribeLoadBalancers(params2)
 
-    params2 := &elbv2.DescribeLoadBalancersInput{
-        LoadBalancerArns: lb,
-    }
-    lbData, err := svc.DescribeLoadBalancers(params2)
+	if err != nil {
+		fmt.Println(err.Error())
+		return info
+	}
+	fmt.Printf("LB DNS: %s\n", *lbData.LoadBalancers[0].DNSName)
 
-    if err != nil {
-        fmt.Println(err.Error())
-        return info
-    }
-    fmt.Printf("LB DNS: %s\n", *lbData.LoadBalancers[0].DNSName)
+	info.DNSName = *lb[0]
+	info.Port = *lbPort
+	return info
+}
 
-    info.DNSName = *lb[0]
-    info.Port = *lbPort
-    return info
+// Helper function to check if the correct config flags are set to use ALBs
+func checkELBFlags(service *bridge.Service) bool {
+	if service.Attrs["eureka_use_elbv2_endpoint"] != "" && service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn {
+		v, err := strconv.ParseBool(service.Attrs["eureka_use_elbv2_endpoint"])
+		if err != nil {
+			log.Printf("eureka: eureka_use_elbv2_endpoint must be valid boolean, was %v : %s", v, err)
+			return false
+		} else {
+			return true
+		}
+	} else {
+		return false
+	}
+}
+
+// RegisterELBv2 - If specified, also register an ELBv2 (application load balancer, ALB) endpoint in eureka, and alter service name
+// for container registrations.  This will mean traffic is directed to the ALB rather than directly to containers
+// though they are still registered in eureka for information purposes
+func RegisterELBv2(service *bridge.Service, registration *eureka.Instance, client eureka.EurekaConnection) {
+	if checkELBFlags(service) {
+		awsMetadata := GetMetadata()
+		elbMetadata := GetELBV2ForContainer(awsMetadata.InstanceID, int64(registration.Port))
+		elbEndpoint := elbMetadata.DNSName + ":" + string(elbMetadata.Port)
+
+		registration.SetMetadataString("has_elbv2", "true")
+		registration.SetMetadataString("elbv2_endpoint", elbEndpoint)
+
+		elbReg := new(eureka.Instance)
+		elbReg.Port = int(elbMetadata.Port)
+		elbReg.IPAddr = elbMetadata.DNSName
+		elbReg.App = service.Name
+		elbReg.VipAddress = elbReg.IPAddr
+		elbReg.HostName = elbReg.IPAddr
+		elbReg.SetMetadataString("is_elbv2", "true")
+		client.RegisterInstance(elbReg)
+
+	}
+}
+
+// DeregisterELBv2 - If specified, and all containers are gone, also deregister the ELBv2 (application load balancer, ALB) endpoint in eureka.
+//
+func DeregisterELBv2(service *bridge.Service, regDNSName string, regPort int64, client eureka.EurekaConnection) {
+	if checkELBFlags(service) {
+		// Check if there are any containers around with this ALB still attached
+		albName := regDNSName + ":" + string(regPort)
+		appName := "CONTAINER_" + service.Name
+		app, err := client.GetApp(appName)
+		if app != nil {
+			for _, instance := range app.Instances {
+				val, err := instance.Metadata.GetString("alb_endpoint")
+				if err == nil && val == albName {
+					log.Printf("Eureka entry still present for one or more ALB linked containers: %s\n", val)
+					return
+				}
+			}
+		}
+		if err != nil {
+			log.Printf("Unable to retrieve app metadata for %s: %s\n", appName, err)
+		}
+
+		if app == nil {
+			elbReg := new(eureka.Instance)
+			elbReg.IPAddr = regDNSName
+			elbReg.App = service.Name
+			elbReg.HostName = elbReg.IPAddr
+			client.DeregisterInstance(elbReg)
+		}
+	}
+}
+
+// HeartbeatELBv2 - Send a heartbeat to eureka for this ELBv2 registration.  Every host running registrator will send heartbeats, meaning they will
+// be received more frequently than the --ttl-refresh interval if there are multiple hosts running registrator.
+//
+func HeartbeatELBv2(service *bridge.Service, registration *eureka.Instance, client eureka.EurekaConnection) {
+	if checkELBFlags(service) {
+		awsMetadata := GetMetadata()
+		elbMetadata := GetELBV2ForContainer(awsMetadata.InstanceID, int64(registration.Port))
+		elbReg := new(eureka.Instance)
+		elbReg.IPAddr = elbMetadata.DNSName
+		elbReg.App = service.Name
+		elbReg.HostName = elbReg.IPAddr
+		client.HeartBeatInstance(elbReg)
+	}
 }

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+    "github.com/aws/aws-sdk-go/service/elbv2"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/aws"
+    "fmt"
+)
+
+// LBInfo represents a ELBv2 endpoint
+type LBInfo struct {
+    DNSName string
+    Port int64
+}
+
+// GetELBV2ForContainer returns an LBInfo struct with the load balancer DNS name and listener port for a given instanceId and port
+// if an error occurs, or the target is not found, an empty LBInfo is returned.
+func GetELBV2ForContainer(instanceID string, port int64) LBInfo {
+
+    var lb []*string
+    var lbPort *int64
+    info := LBInfo{}
+
+    sess, err := session.NewSession()
+    if err != nil {
+        fmt.Println("failed to create session,", err)
+        return info 
+    }
+    svc := elbv2.New(sess)
+
+    // Loop through target group pages and check for port and instanceID
+    //
+    params := &elbv2.DescribeTargetGroupsInput{
+        PageSize: aws.Int64(10),
+
+    }
+    tgs, err := svc.DescribeTargetGroups(params)
+
+    if err != nil {
+        // Print the error, cast err to awserr.Error to get the Code and
+        // Message from an error.
+        fmt.Println(err.Error())
+        return info
+    }
+
+    // Check each target group for a matching port and instanceID
+    // We assume that there is only one LB for the target group (though the data structure allows more)
+    for _, tg := range tgs.TargetGroups {
+        params4 := &elbv2.DescribeTargetHealthInput{
+            TargetGroupArn: aws.String(*tg.TargetGroupArn),
+        }
+        tarH, err := svc.DescribeTargetHealth(params4)
+
+        for _, thd := range tarH.TargetHealthDescriptions {
+            if *thd.Target.Port == port && *thd.Target.Id == instanceID {
+                lb = tg.LoadBalancerArns
+                lbPort = tg.Port
+            }
+
+        }
+        if err != nil {
+            fmt.Println(err.Error())
+            return info
+        }
+        fmt.Printf("LB is: %v\n", *lb[0])
+        fmt.Printf("LB Port is: %v\n", *lbPort)
+    }
+
+    params2 := &elbv2.DescribeLoadBalancersInput{
+        LoadBalancerArns: lb,
+    }
+    lbData, err := svc.DescribeLoadBalancers(params2)
+
+    if err != nil {
+        fmt.Println(err.Error())
+        return info
+    }
+    fmt.Printf("LB DNS: %s\n", *lbData.LoadBalancers[0].DNSName)
+
+    info.DNSName = *lb[0]
+    info.Port = *lbPort
+    return info
+}

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+type Metadata struct {
+	InstanceID       string
+	PrivateIP        string
+	PublicIP         string
+	PrivateHostname  string
+	PublicHostname   string
+	AvailabilityZone string
+}
+
+func getDataOrFail(svc *ec2metadata.EC2Metadata, key string) string {
+	val, err := svc.GetMetadata(key)
+	if err != nil {
+		fmt.Printf("Unable to retrieve %s from the EC2 instance: %s\n", key, err)
+		return ""
+	}
+	return val
+}
+
+func GetMetadata() *Metadata {
+	log.Println("Attempting to retrieve AWS metadata.")
+	sess, err := session.NewSession()
+	if err != nil {
+		fmt.Printf("Unable to connect to the EC2 metadata service: %s\n", err)
+	}
+	svc := ec2metadata.New(sess)
+	m := new(Metadata)
+	if svc.Available() {
+		m.InstanceID = getDataOrFail(svc, "instance-id")
+		m.PrivateIP = getDataOrFail(svc, "local-ipv4")
+		m.PublicIP = getDataOrFail(svc, "public-ipv4")
+		m.PrivateHostname = getDataOrFail(svc, "local-hostname")
+		m.PublicHostname = getDataOrFail(svc, "public-hostname")
+		m.AvailabilityZone = getDataOrFail(svc, "placement/availability-zone")
+	} else {
+		fmt.Println("AWS metadata not available :(")
+	}
+	return m
+}

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -15,6 +15,7 @@ type Metadata struct {
 	PrivateHostname  string
 	PublicHostname   string
 	AvailabilityZone string
+	Region           string
 }
 
 func getDataOrFail(svc *ec2metadata.EC2Metadata, key string) string {
@@ -34,7 +35,14 @@ func GetMetadata() *Metadata {
 	}
 	svc := ec2metadata.New(sess)
 	m := new(Metadata)
+
 	if svc.Available() {
+		ident, err := svc.GetInstanceIdentityDocument()
+		if err != nil {
+			m.Region = ""
+		} else {
+			m.Region = ident.Region
+		}
 		m.InstanceID = getDataOrFail(svc, "instance-id")
 		m.PrivateIP = getDataOrFail(svc, "local-ipv4")
 		m.PublicIP = getDataOrFail(svc, "public-ipv4")

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -176,8 +176,8 @@ the host ip if not.
 The following defaults are set and can be overridden with service attributes:
 ```
 	SERVICE_EUREKA_STATUS = UP
-	SERVICE_EUREKA_VIP = Service IP
-	SERVICE_EUREKA_IPADDR = Service IP
+	SERVICE_EUREKA_VIP = Service IP (ignored if using SERVICE_EUREKA_REGISTER_AWS_PUBLIC_IP)
+	SERVICE_EUREKA_IPADDR = Service IP (ignored if using SERVICE_EUREKA_REGISTER_AWS_PUBLIC_IP)
 	SERVICE_EUREKA_LEASEINFO_RENEWALINTERVALINSECS = 30
 	SERVICE_EUREKA_LEASEINFO_DURATIONINSECS = 90
 	SERVICE_EUREKA_DATACENTERINFO_NAME = Amazon
@@ -197,8 +197,16 @@ These will appear in eureka inside a metadata tag.  See https://github.com/hudl/
 
 If the Amazon Datacenter type is used, the following additional values are supported:
 ```	
-	SERVICE_EUREKA_REGISTER_AWS_PUBLIC_IP = false (if true, set VIP and IPADDR values to AWS public IP)
-	SERVICE_EUREKA_USE_ELBV2_ENDPOINT = false (if true, an entry will be added for an ELBv2 connected to a container target group in ECS - see below for more details)
+	
+If the Amazon Datacenter type is used, the following additional values are supported:
+```	
+SERVICE_EUREKA_DATACENTERINFO_AUTO_POPULATE=false (if set to true, will attempt to populate datacenter info automatically)
+SERVICE_EUREKA_DATACENTERINFO_PUBLICHOSTNAME = Host IP (ignored if using automatic population)
+SERVICE_EUREKA_DATACENTERINFO_PUBLICIPV4 = Host IP (ignored if using automatic population)
+SERVICE_EUREKA_DATACENTERINFO_LOCALIPV4 = Host or Container IP (depending on -internal flag, ignored if using automatic population)
+SERVICE_EUREKA_DATACENTERINFO_LOCALHOSTNAME = Host or Container IP (depending on -internal flag, ignored if using automatic population)
+SERVICE_EUREKA_REGISTER_AWS_PUBLIC_IP = false (if true, set VIP and IPADDR values to AWS public IP, ignored if NOT using automatic population)
+SERVICE_EUREKA_USE_ELBV2_ENDPOINT = false (if true, an entry will be added for an ELBv2 connected to a container target group in ECS - see below for more details)
 ```
 AWS datacenter metadata will be automatically populated.  _However_, the `InstanceID` will instead match `hostName`, which is the unique identifier for the container (Host_Port).  This is due to limitations in the eureka server.  
 Instead, a new metadata tag, `aws_instanceID` has the underlying host instanceID.

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -176,19 +176,13 @@ the host ip if not.
 The following defaults are set and can be overridden with service attributes:
 ```
 	SERVICE_EUREKA_STATUS = UP
-	SERVICE_EUREKA_VIP = Service Name
+	SERVICE_EUREKA_VIP = Service IP
+	SERVICE_EUREKA_IPADDR = Service IP
 	SERVICE_EUREKA_LEASEINFO_RENEWALINTERVALINSECS = 30
 	SERVICE_EUREKA_LEASEINFO_DURATIONINSECS = 90
 	SERVICE_EUREKA_DATACENTERINFO_NAME = Amazon
 ```
-	
-If the Amazon Datacenter type is used, the following additional values are supported:
-```	
-	SERVICE_EUREKA_DATACENTERINFO_PUBLICHOSTNAME = Host IP
-	SERVICE_EUREKA_DATACENTERINFO_PUBLICIPV4 = Host IP
-	SERVICE_EUREKA_DATACENTERINFO_LOCALIPV4 = Host or Container IP (depending on -internal flag)
-	SERVICE_EUREKA_DATACENTERINFO_LOCALHOSTNAME = Host or Container IP (depending on -internal flag)
-```
+
 
 To set custom eureka metadata for your own purposes, you can use service attributes prefixed with SERVICE_EUREKA_METADATA_, e.g.:
 ```
@@ -196,3 +190,70 @@ To set custom eureka metadata for your own purposes, you can use service attribu
 	SERVICE_EUREKA_METADATA_BE_AWESOME=true
 ```
 These will appear in eureka inside a metadata tag.  See https://github.com/hudl/fargo/blob/master/metadata.go for some ideas on how to use them.
+
+
+
+### AWS Datacenter Metadata Population
+
+If the Amazon Datacenter type is used, the following additional values are supported:
+```	
+	SERVICE_EUREKA_REGISTER_AWS_PUBLIC_IP = false (if true, set VIP and IPADDR values to AWS public IP)
+	SERVICE_EUREKA_USE_ELBV2_ENDPOINT = false (if true, an entry will be added for an ELBv2 connected to a container target group in ECS - see below for more details)
+```
+AWS datacenter metadata will be automatically populated.  _However_, the `InstanceID` will instead match `hostName`, which is the unique identifier for the container (Host_Port).  This is due to limitations in the eureka server.  
+Instead, a new metadata tag, `aws_instanceID` has the underlying host instanceID.
+
+For any of this to work, it requires properly functioning IAM roles for your container host.  On ECS, this will just work  - however, if you are running custom container hosts on EC2 with kubernetes or the like, then it may need further setup for the AWS metadata to work.
+
+Have a look at this to help with that: https://github.com/jtblin/kube2iam - the concept is a metadata proxy, which will allow containers to see the underlying AWS metadata.
+
+
+### Using ELBv2
+
+If you are using ECS (EC2 Container Service) and run containers in target groups, with an Application Load Balancer in front of them (described by Amazon as ELBv2) then you can have registrator add the load 
+balancer reference to eureka too.  It may work with custom EC2 instances behind a target group too, but has not been tested.  This has the following properties at present:
+
+- It is piggybacked off container registration/deregistration/heartbeats, so it will not happen independently.
+- It is not persistent, so if all the containers disappear, so will the eureka registration to the supporting ELBv2 (this might be what you want, or it might not)
+- It works safely across multiple hosts, you'll only get one entry for the ELBv2 endpoint, no matter how many ECS hosts are running registrator.
+- ELBv2 Heartbeats happen as and when container heartbeat happens.  So, if you have four containers on an ELBv2, the ELBv2 will get a heartbeat for every one of them, on whatever you set your heartbeat interval is set to. In practice, this ought not be a problem.
+
+If you set the flag `SERVICE_EUREKA_USE_ELBV2_ENDPOINT=true` AND you have `SERVICE_EUREKA_DATACENTERINFO_NAME = Amazon` then this feature is enabled.  It will:
+
+1. Attempt to connect to the AWS service using the IAM role of the container host.  In ECS, this should just work.  It will find the region associated with the container host, and connect using that region.
+2. This will alter the app name to be prefixed by CONTAINER_ for the containers beneath it.
+3. A new entry is added to eureka representing the ALB, and removed when the last container disappears. This entry will have some basic information, such as the hostname and port endpoint. It also has an `is_elbv2flag` in metadata.
+4. The containers underneath the ALB have extra information added in metadata about being attached to the ELB; the `elbv2_endpoint` metadata and `has_elbv2` flag.
+
+
+#### IAM Policy
+In order for this to work (you will receive a log error if not) the IAM role attached to the ECS host must have something like the following additional policy:
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1482328407000",
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:DescribeInstanceHealth",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeLoadBalancerPolicyTypes",
+                "elasticloadbalancing:DescribeLoadBalancerPolicies",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetHealth"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+```
+

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -2,6 +2,8 @@ package eureka
 
 import (
 	"github.com/gliderlabs/registrator/bridge"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	eureka "github.com/hudl/fargo"
 	"log"
 	"net/url"
@@ -44,15 +46,53 @@ func (r *EurekaAdapter) Ping() error {
 	return nil
 }
 
+type AWSMetadata struct {
+	InstanceID string
+	PrivateIP string
+	PublicIP string
+	PrivateHostname string
+	PublicHostname string
+} 
+
+func getDataOrFail(svc *EC2Metadata, key *string) string {
+	var val, err := svc.GetMetadata(key)
+	if err != nil {
+		log.Printf("Unable to retrieve %s from the EC2 instance: %s\n", key, err)
+		return ""
+	}
+	return val
+}
+
+func getAWSMetadata() *AWSMetadata {
+	log.Println("Attempting to retrieve AWS metadata.")
+	sess, err := session.NewSession()
+	if err != nil {
+		log.Printf("Unable to connect to the EC2 metadata service: %s\n", err)
+	}
+	svc := ec2metadata.New(sess)
+	m := new(AWSMetadata)
+	if svc.Available() {
+		m.InstanceID = getDataOrFail(svc, "instance-id")
+		m.PrivateIP = getDataOrFail(svc, "local-ipv4")
+		m.PublicIP = getDataOrFail(svc, "public-ipv4")
+		m.PrivateHostname = getDataOrFail(svc, "local-hostname")
+		m.PublicHostname = getDataOrFail(svc, "public-hostname")
+	} else {
+		log.Println("AWS metadata not available :(")
+	}
+	return m
+}
+
 func instanceInformation(service *bridge.Service) *eureka.Instance {
 
 	registration := new(eureka.Instance)
-	uniqueId := service.IP + ":" + strconv.Itoa(service.Port)
+	uniqueId := service.Origin.ContainerName + "_" + service.IP + ":" + strconv.Itoa(service.Port)
 
 	registration.HostName = uniqueId
 	registration.App = service.Name
 	registration.Port = service.Port
-	registration.VipAddress = ShortHandTernary(service.Attrs["eureka_vip"], service.Name)
+	registration.IPAddr = ShortHandTernary(service.Attrs["eureka_ipaddr"], service.IP)
+	registration.VipAddress = ShortHandTernary(service.Attrs["eureka_vip"], service.IP)
 
 	if service.Attrs["eureka_status"] == string(eureka.DOWN) {
 		registration.Status = eureka.DOWN
@@ -91,14 +131,16 @@ func instanceInformation(service *bridge.Service) *eureka.Instance {
 	}
 
 	if service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn {
+		awsMetadata := getAWSMetaData()
 		registration.DataCenterInfo.Name = eureka.Amazon
 		registration.DataCenterInfo.Metadata = eureka.AmazonMetadataType{
-			InstanceID:     uniqueId,
-			PublicHostname: ShortHandTernary(service.Attrs["eureka_datacenterinfo_publichostname"], service.Origin.HostIP),
-			PublicIpv4:     ShortHandTernary(service.Attrs["eureka_datacenterinfo_publicipv4"], service.Origin.HostIP),
-			LocalHostname:  ShortHandTernary(service.Attrs["eureka_datacenterinfo_localhostname"], service.IP),
-			HostName:       ShortHandTernary(service.Attrs["eureka_datacenterinfo_localhostname"], service.IP),
-			LocalIpv4:      ShortHandTernary(service.Attrs["eureka_datacenterinfo_localipv4"], service.IP),
+			InstanceID:       	awsMetadata.InstanceID,
+			AvailabilityZone:	awsMetadata.AvailabilityZone,
+			PublicHostname:		awsMetadata.PublicHostname,
+			PublicIpv4:     	awsMetadata.PublicIP,
+			LocalHostname:  	awsMetadata.PrivateHostname,
+			HostName:       	awsMetadata.PrivateHostname,
+			LocalIpv4:      	awsMetadata.PrivateIP,
 		}
 	} else {
 		registration.DataCenterInfo.Name = eureka.MyOwn

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -118,6 +118,7 @@ func instanceInformation(service *bridge.Service) *eureka.Instance {
 			AvailabilityZone: awsMetadata.AvailabilityZone,
 			PublicHostname:   awsMetadata.PublicHostname,
 			PublicIpv4:       awsMetadata.PublicIP,
+			InstanceID:       registration.HostName, // This is deliberate - due to limitations in uniqueIDs
 			LocalHostname:    awsMetadata.PrivateHostname,
 			HostName:         awsMetadata.PrivateHostname,
 			LocalIpv4:        awsMetadata.PrivateIP,

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -52,10 +52,11 @@ type AWSMetadata struct {
 	PublicIP string
 	PrivateHostname string
 	PublicHostname string
+	AvailabilityZone string
 } 
 
-func getDataOrFail(svc *EC2Metadata, key *string) string {
-	var val, err := svc.GetMetadata(key)
+func getDataOrFail(svc *ec2metadata.EC2Metadata, key string) string {
+	val, err := svc.GetMetadata(key)
 	if err != nil {
 		log.Printf("Unable to retrieve %s from the EC2 instance: %s\n", key, err)
 		return ""
@@ -131,7 +132,7 @@ func instanceInformation(service *bridge.Service) *eureka.Instance {
 	}
 
 	if service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn {
-		awsMetadata := getAWSMetaData()
+		awsMetadata := getAWSMetadata()
 		registration.DataCenterInfo.Name = eureka.Amazon
 		registration.DataCenterInfo.Metadata = eureka.AmazonMetadataType{
 			InstanceID:       	awsMetadata.InstanceID,

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -88,7 +88,7 @@ func getAWSMetadata() *AWSMetadata {
 func instanceInformation(service *bridge.Service) *eureka.Instance {
 
 	registration := new(eureka.Instance)
-	uniqueId := service.Origin.ContainerID + "_" + service.IP + ":" + strconv.Itoa(service.Port)
+	uniqueId := service.IP + ":" + strconv.Itoa(service.Port) + "_" + service.Origin.ContainerID
 
 	registration.HostName = uniqueId
 	registration.App = service.Name

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -1,14 +1,14 @@
 package eureka
 
 import (
-	"github.com/gliderlabs/registrator/bridge"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	eureka "github.com/hudl/fargo"
 	"log"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/gliderlabs/registrator/aws"
+	"github.com/gliderlabs/registrator/bridge"
+	eureka "github.com/hudl/fargo"
 )
 
 const DefaultInterval = "10s"
@@ -26,7 +26,6 @@ func (f *Factory) New(uri *url.URL) bridge.RegistryAdapter {
 	} else {
 		client = eureka.NewConn("http://eureka:8761")
 	}
-
 	return &EurekaAdapter{client: client}
 }
 
@@ -46,48 +45,10 @@ func (r *EurekaAdapter) Ping() error {
 	return nil
 }
 
-type AWSMetadata struct {
-	InstanceID string
-	PrivateIP string
-	PublicIP string
-	PrivateHostname string
-	PublicHostname string
-	AvailabilityZone string
-} 
-
-func getDataOrFail(svc *ec2metadata.EC2Metadata, key string) string {
-	val, err := svc.GetMetadata(key)
-	if err != nil {
-		log.Printf("Unable to retrieve %s from the EC2 instance: %s\n", key, err)
-		return ""
-	}
-	return val
-}
-
-func getAWSMetadata() *AWSMetadata {
-	log.Println("Attempting to retrieve AWS metadata.")
-	sess, err := session.NewSession()
-	if err != nil {
-		log.Printf("Unable to connect to the EC2 metadata service: %s\n", err)
-	}
-	svc := ec2metadata.New(sess)
-	m := new(AWSMetadata)
-	if svc.Available() {
-		m.InstanceID = getDataOrFail(svc, "instance-id")
-		m.PrivateIP = getDataOrFail(svc, "local-ipv4")
-		m.PublicIP = getDataOrFail(svc, "public-ipv4")
-		m.PrivateHostname = getDataOrFail(svc, "local-hostname")
-		m.PublicHostname = getDataOrFail(svc, "public-hostname")
-		m.AvailabilityZone = getDataOrFail(svc, "placement/availability-zone")
-	} else {
-		log.Println("AWS metadata not available :(")
-	}
-	return m
-}
-
 func instanceInformation(service *bridge.Service) *eureka.Instance {
 
 	registration := new(eureka.Instance)
+	var awsMetadata *aws.Metadata
 	uniqueId := service.IP + ":" + strconv.Itoa(service.Port) + "_" + service.Origin.ContainerID
 
 	registration.HostName = uniqueId
@@ -100,20 +61,7 @@ func instanceInformation(service *bridge.Service) *eureka.Instance {
 		registration.Status = eureka.UP
 	}
 
-	if service.Attrs["eureka_register_aws_public_ip"] != "" {
-		v, err := strconv.ParseBool(service.Attrs["eureka_register_aws_public_ip"])
-		if err != nil {
-			log.Printf("eureka: eureka_register_aws_public_ip must be valid boolean, was %s : %s", v, err)
-		} else {
-			awsMetadata := getAWSMetadata()
-			registration.IPAddr = ShortHandTernary(service.Attrs["eureka_ipaddr"], awsMetadata.PublicIP)
-			registration.VipAddress = ShortHandTernary(service.Attrs["eureka_vip"], awsMetadata.PublicIP)
-		}
-	} else {
-		registration.IPAddr = ShortHandTernary(service.Attrs["eureka_ipaddr"], service.IP)
-		registration.VipAddress = ShortHandTernary(service.Attrs["eureka_vip"], service.IP)
-	}
-
+	// Set the renewal interval in seconds, or default 30
 	if service.Attrs["eureka_leaseinfo_renewalintervalinsecs"] != "" {
 		v, err := strconv.Atoi(service.Attrs["eureka_leaseinfo_renewalintervalinsecs"])
 		if err != nil {
@@ -125,6 +73,7 @@ func instanceInformation(service *bridge.Service) *eureka.Instance {
 		registration.LeaseInfo.RenewalIntervalInSecs = 30
 	}
 
+	// Set the lease expiry timeout, or default 90
 	if service.Attrs["eureka_leaseinfo_durationinsecs"] != "" {
 		v, err := strconv.Atoi(service.Attrs["eureka_leaseinfo_durationinsecs"])
 		if err != nil {
@@ -144,20 +93,47 @@ func instanceInformation(service *bridge.Service) *eureka.Instance {
 		}
 	}
 
+	// If you are not running locally, check AWS API for metadata
 	if service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn {
-		awsMetadata := getAWSMetadata()
+		awsMetadata = aws.GetMetadata()
 		registration.DataCenterInfo.Name = eureka.Amazon
 		registration.DataCenterInfo.Metadata = eureka.AmazonMetadataType{
-			InstanceID:       	awsMetadata.InstanceID,
-			AvailabilityZone:	awsMetadata.AvailabilityZone,
-			PublicHostname:		awsMetadata.PublicHostname,
-			PublicIpv4:     	awsMetadata.PublicIP,
-			LocalHostname:  	awsMetadata.PrivateHostname,
-			HostName:       	awsMetadata.PrivateHostname,
-			LocalIpv4:      	awsMetadata.PrivateIP,
+			InstanceID:       awsMetadata.InstanceID,
+			AvailabilityZone: awsMetadata.AvailabilityZone,
+			PublicHostname:   awsMetadata.PublicHostname,
+			PublicIpv4:       awsMetadata.PublicIP,
+			LocalHostname:    awsMetadata.PrivateHostname,
+			HostName:         awsMetadata.PrivateHostname,
+			LocalIpv4:        awsMetadata.PrivateIP,
 		}
 	} else {
 		registration.DataCenterInfo.Name = eureka.MyOwn
+	}
+
+	// If flag is set, register the AWS public IP as the endpoint instead of the private one
+	if service.Attrs["eureka_register_aws_public_ip"] != "" && service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn {
+		v, err := strconv.ParseBool(service.Attrs["eureka_register_aws_public_ip"])
+		if err != nil {
+			log.Printf("eureka: eureka_register_aws_public_ip must be valid boolean, was %v : %s", v, err)
+		} else {
+			registration.IPAddr = ShortHandTernary(service.Attrs["eureka_ipaddr"], awsMetadata.PublicIP)
+			registration.VipAddress = ShortHandTernary(service.Attrs["eureka_vip"], awsMetadata.PublicIP)
+		}
+	} else {
+		registration.IPAddr = ShortHandTernary(service.Attrs["eureka_ipaddr"], service.IP)
+		registration.VipAddress = ShortHandTernary(service.Attrs["eureka_vip"], service.IP)
+	}
+
+	// If specified, lookup the ELBv2 (application load balancer) DNS name and port, use these to register with eureka, instead of the container itself
+	if service.Attrs["eureka_use_elbv2_endpoint"] != "" && service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn {
+		v, err := strconv.ParseBool(service.Attrs["eureka_use_elbv2_endpoint"])
+		if err != nil {
+			log.Printf("eureka: eureka_use_elbv2_endpoint must be valid boolean, was %v : %s", v, err)
+		} else {
+			elbMetadata := aws.GetELBV2ForContainer(awsMetadata.InstanceID, int64(service.Port))
+			registration.HostName = elbMetadata.DNSName
+			registration.Port = int(elbMetadata.Port)
+		}
 	}
 
 	return registration

--- a/modules.go
+++ b/modules.go
@@ -4,8 +4,7 @@ import (
 	_ "github.com/gliderlabs/registrator/consul"
 	_ "github.com/gliderlabs/registrator/consulkv"
 	_ "github.com/gliderlabs/registrator/etcd"
+	_ "github.com/gliderlabs/registrator/eureka"
 	_ "github.com/gliderlabs/registrator/skydns2"
 	_ "github.com/gliderlabs/registrator/zookeeper"
-	_ "github.com/gliderlabs/registrator/eureka"
-
 )


### PR DESCRIPTION
This branch adds some hudl required functionality:

1. Get AWS metadata to populate datacenter info correctly if the `SERVICE_eureka_datacenterinfo_auto_populate` flag is set to true.

2. Change the `instanceID` in the datacenter info to be a unique ID (comprised of IP_Port) which matches `hostName`.  This is a required workaround, because otherwise eureka does not correctly identify each container uniquely.  The actual instanceID has been moved to an `aws_instanceID` metadata item.

3. Add a new metadata item for `containerID`

4. Add an `is_container` flag to the metadata for each container

5. Add a `SERVICE_eureka_register_aws_public_ip` boolean flag, to register the AWS public IP instead of the private IP of the container host if required.

6. Add the ability to register an ELBv2 (Application Load Balancer) to eureka as well as containers it references in a target group, if the `SERVICE_eureka_use_elbv2_endpoint` boolean flag is true: 

- This will alter the app name to be prefixed by `CONTAINER_` for the containers beneath it.
- A new entry is added to eureka representing the ALB, and removed when the last container disappears.  This entry will have some basic information, such as the hostname and port endpoint.  It also has an `is_elbv2`flag in metadata.
- The containers underneath the ALB have extra information added in metadata about being attached to the ELB; the `elbv2_endpoint` metadata and `has_elbv2` flag.

*Note:* Currently the ALB register/deregister and heatbeat operations are all piggybacked onto the underlying containers.  This may not be entirely desirable, but some major refactoring would be required to make ALB registrations persistent, so it's a good start for now.

