### PR TITLE
Add metadata unit tests and some fixes

### DIFF
--- a/aws/elb.go
+++ b/aws/elb.go
@@ -114,8 +114,8 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance) *eureka.
 	elbStrPort := strconv.FormatInt(elbMetadata.Port, 10)
 	elbEndpoint := elbMetadata.DNSName + "_" + elbStrPort
 
-	registration.SetMetadataString("has_elbv2", "true")
-	registration.SetMetadataString("elbv2_endpoint", elbEndpoint)
+	registration.SetMetadataString("has-elbv2", "true")
+	registration.SetMetadataString("elbv2-endpoint", elbEndpoint)
 
 	elbReg := new(eureka.Instance)
 
@@ -134,7 +134,7 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance) *eureka.
 	elbReg.VipAddress = elbReg.IPAddr
 	elbReg.HostName = elbMetadata.DNSName
 	elbReg.DataCenterInfo.Name = eureka.Amazon
-	elbReg.SetMetadataString("is_elbv2", "true")
+	elbReg.SetMetadataString("is-elbv2", "true")
 	return elbReg
 }
 

--- a/aws/metadata_test.go
+++ b/aws/metadata_test.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+)
+
+// Mock out a metadata interface and implement basic methods
+type testMetadata struct {
+	m       map[string]string
+	isError error
+	ec2Doc  ec2metadata.EC2InstanceIdentityDocument
+}
+
+var _ IEC2Metadata = (*testMetadata)(nil)
+
+func (t *testMetadata) GetMetadata(key string) (string, error) {
+	if t.m[key] != "" {
+		return t.m[key], nil
+	}
+	return "", t.isError
+}
+func (t *testMetadata) Available() bool {
+	return true
+}
+func (t *testMetadata) GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error) {
+	return t.ec2Doc, t.isError
+}
+func getIdentDoc() ec2metadata.EC2InstanceIdentityDocument {
+	doc := ec2metadata.EC2InstanceIdentityDocument{
+		Region:           "us-east-1",
+		InstanceID:       "i-12341234",
+		AvailabilityZone: "c",
+	}
+	return doc
+}
+
+// Test metadata is returned correctly
+func TestGetDataOrFailSuccess(t *testing.T) {
+	metadata := &testMetadata{}
+	metadata.m = map[string]string{"test": "test1"}
+	result := getDataOrFail(metadata, "test")
+	if result != "test1" {
+		t.Error("Metadata not retrieved correctly by GetDataOrFail")
+	}
+}
+
+// Test metadata returns empty string if the key is missing
+func TestGetDataOrFailFail(t *testing.T) {
+	metadata := &testMetadata{}
+	result := getDataOrFail(metadata, "test")
+	if result != "" {
+		t.Error("Incorrectly returned non-empty string")
+	}
+}
+
+// Test for a failure to retrieve region
+func TestRetrieveMetadataCatchesError(t *testing.T) {
+	metadata := &testMetadata{}
+	metadata.m = map[string]string{"test": "test1"}
+	metadata.ec2Doc = getIdentDoc()
+	metadata.isError = errors.New("This is supposed to fail")
+
+	r := retrieveMetadata(metadata)
+	if r.Region != "" {
+		t.Error("Region is supposed to be empty.")
+	}
+}
+
+// Test for a successful retrieval of all data
+func TestRetrieveMetadata(t *testing.T) {
+	metadata := &testMetadata{}
+	metadata.m = map[string]string{
+		"test":                        "test1",
+		"instance-id":                 "i-12341234",
+		"local-ipv4":                  "1.2.3.4",
+		"public-ipv4":                 "4.5.6.7",
+		"local-hostname":              "host1",
+		"public-hostname":             "host2",
+		"placement/availability-zone": "us-east-1c",
+		"region":                      getIdentDoc().Region,
+	}
+	metadata.ec2Doc = getIdentDoc()
+	metadata.isError = nil
+	r := retrieveMetadata(metadata)
+
+	checkVS(t, metadata.m, "region", r.Region)
+	checkVS(t, metadata.m, "placement/availability-zone", r.AvailabilityZone)
+	checkVS(t, metadata.m, "public-ipv4", r.PublicIP)
+	checkVS(t, metadata.m, "local-ipv4", r.PrivateIP)
+	checkVS(t, metadata.m, "local-hostname", r.PrivateHostname)
+	checkVS(t, metadata.m, "public-hostname", r.PublicHostname)
+	checkVS(t, metadata.m, "instance-id", r.InstanceID)
+
+}
+
+// Check one metadata value vs result and print errors if failed
+func checkVS(t *testing.T, m map[string]string, k string, val string) {
+	if val != m[k] {
+		t.Errorf("Metadata %s: expected %v, actual: %s ", k, m[k], val)
+	}
+}

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -101,6 +101,7 @@ func servicePort(container *dockerapi.Container, port dockerapi.Port, published 
 		ExposedIP:         eip,
 		PortType:          ept,
 		ContainerID:       container.ID,
+		ContainerName:     container.Name,
 		ContainerHostname: container.Config.Hostname,
 		container:         container,
 	}

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -118,14 +118,15 @@ func instanceInformation(service *bridge.Service) *eureka.Instance {
 	}
 
 	// Metadata flag for a container
-	registration.SetMetadataString("is_container", string("true"))
-	registration.SetMetadataString("containerID", service.Origin.ContainerID)
+	registration.SetMetadataString("is-container", string("true"))
+	registration.SetMetadataString("container-id", service.Origin.ContainerID)
+	registration.SetMetadataString("container-name", service.Origin.ContainerName)
 
 	// If AWS metadata collection is enabled, use it
 	if service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn && checkBooleanFlag(service, "eureka_datacenterinfo_auto_populate") {
 		awsMetadata = aws.GetMetadata()
 		// Set the instanceID here, because we don't want eureka to use it as a uniqueID
-		registration.SetMetadataString("aws_InstanceId", awsMetadata.InstanceID)
+		registration.SetMetadataString("aws-instance-id", awsMetadata.InstanceID)
 		registration.DataCenterInfo.Name = eureka.Amazon
 		registration.DataCenterInfo.Metadata = eureka.AmazonMetadataType{
 			AvailabilityZone: awsMetadata.AvailabilityZone,


### PR DESCRIPTION
- Add unit tests for metadata, and some refactoring to allow testability
- Some small metadata fixes discovered during testing (such as container name being missing from bridge.go)
- Make metadata naming consistent - use `-` instead of `_`.