### PR TITLE
Add ELB Unit Tests, Improve Performance

### DIFF
--- a/aws/elb.go
+++ b/aws/elb.go
@@ -19,10 +19,19 @@ type LBInfo struct {
 	Port    int64
 }
 
+var lbCache = make(map[string]*LBInfo)
+
 // getELBV2ForContainer returns an LBInfo struct with the load balancer DNS name and listener port for a given instanceId and port
 // if an error occurs, or the target is not found, an empty LBInfo is returned. Return the DNS:port pair as an identifier to put in the container's registration metadata
 // Pass it the instanceID for the docker host, and the the host port to lookup the associated ELB.
-func getELBV2ForContainer(instanceID string, port int64) (lbinfo *LBInfo, err error) {
+func getELBV2ForContainer(instanceID string, port int64, useCache bool) (lbinfo *LBInfo, err error) {
+
+	// Retrieve from basic cache (for heartbeats)
+	cacheKey := instanceID + "_" + strconv.FormatInt(port, 10)
+	if useCache && lbCache[cacheKey] != nil {
+		log.Println("Retrieving value from cache.")
+		return lbCache[cacheKey], nil
+	}
 
 	var lb []*string
 	var lbPort *int64
@@ -84,6 +93,10 @@ func getELBV2ForContainer(instanceID string, port int64) (lbinfo *LBInfo, err er
 
 	info.DNSName = *lbData.LoadBalancers[0].DNSName
 	info.Port = *lbPort
+
+	// Add to a basic cache for heartbeats
+	lbCache[cacheKey] = info
+
 	return info, err
 }
 
@@ -95,16 +108,17 @@ func CheckELBFlags(service *bridge.Service) bool {
 			log.Printf("eureka: eureka_use_elbv2_endpoint must be valid boolean, was %v : %s", v, err)
 			return false
 		}
-		return true
+		return v
 	}
 	return false
 }
 
 // Helper function to create a registration struct, and change container registration
-func setRegInfo(service *bridge.Service, registration *eureka.Instance) *eureka.Instance {
+func setRegInfo(service *bridge.Service, registration *eureka.Instance, useCache bool) *eureka.Instance {
 
 	awsMetadata := GetMetadata()
-	elbMetadata, err := getELBV2ForContainer(awsMetadata.InstanceID, int64(registration.Port))
+
+	elbMetadata, err := getELBV2ForContainer(awsMetadata.InstanceID, int64(registration.Port), useCache)
 
 	if err != nil {
 		log.Printf("Unable to find associated ELBv2 for: %s, Error: %s\n", registration.HostName, err)
@@ -120,8 +134,6 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance) *eureka.
 	elbReg := new(eureka.Instance)
 
 	// Put a little metadata in here as required - setting InstanceID to the ELB endpoint prevents double registration
-	elbReg.DataCenterInfo.Name = eureka.Amazon
-
 	elbReg.DataCenterInfo.Metadata = eureka.AmazonMetadataType{
 		PublicHostname: elbMetadata.DNSName,
 		HostName:       elbMetadata.DNSName,
@@ -144,7 +156,7 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance) *eureka.
 func RegisterELBv2(service *bridge.Service, registration *eureka.Instance, client eureka.EurekaConnection) {
 	if CheckELBFlags(service) {
 		log.Printf("Found ELBv2 flags, will attempt to register LB for: %s\n", registration.HostName)
-		elbReg := setRegInfo(service, registration)
+		elbReg := setRegInfo(service, registration, false)
 		if elbReg != nil {
 			client.RegisterInstance(elbReg)
 		}
@@ -192,7 +204,7 @@ func HeartbeatELBv2(service *bridge.Service, registration *eureka.Instance, clie
 	if CheckELBFlags(service) {
 		log.Printf("Heartbeating ELBv2 for container: %s)\n", registration.HostName)
 
-		elbReg := setRegInfo(service, registration)
+		elbReg := setRegInfo(service, registration, true)
 		if elbReg != nil {
 			client.HeartBeatInstance(elbReg)
 		}

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -1,0 +1,196 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gliderlabs/registrator/bridge"
+	eureka "github.com/hudl/fargo"
+)
+
+// Test_getELBV2ForContainer - Test expected values are returned
+func Test_getELBV2ForContainer(t *testing.T) {
+
+	// Setup cache
+	lbWant := LBInfo{
+		DNSName: "",
+		Port:    int64(1234),
+	}
+	lbCache["instance-123_1234"] = &lbWant
+
+	type args struct {
+		instanceID string
+		port       int64
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantLbinfo *LBInfo
+		wantErr    bool
+	}{
+		{
+			name:       "should match",
+			args:       args{instanceID: "instance-123", port: int64(1234)},
+			wantErr:    false,
+			wantLbinfo: &lbWant,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotLbinfo, err := getELBV2ForContainer(tt.args.instanceID, tt.args.port, true)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getELBV2ForContainer() error = %+v, wantErr %+v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotLbinfo, tt.wantLbinfo) {
+				t.Errorf("getELBV2ForContainer() = %+v, want %+v", gotLbinfo, tt.wantLbinfo)
+			}
+		})
+	}
+}
+
+// TestCheckELBFlags - Test that ELBv2 flags are evaulated correctly
+func TestCheckELBFlags(t *testing.T) {
+
+	svcFalse := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_use_elbv2_endpoint":  "false",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+	}
+
+	svcFalse2 := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_use_elbv2_endpoint":  "true",
+			"eureka_datacenterinfo_name": "MyOwn",
+		},
+	}
+
+	svcTrue := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_use_elbv2_endpoint":  "true",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+	}
+
+	type args struct {
+		service *bridge.Service
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should be false",
+			args: args{service: &svcFalse},
+			want: false,
+		},
+		{
+			name: "should be false again",
+			args: args{service: &svcFalse2},
+			want: false,
+		},
+		{
+			name: "should be true",
+			args: args{service: &svcTrue},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckELBFlags(tt.args.service); got != tt.want {
+				t.Errorf("CheckELBFlags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_setRegInfo - Test that registration struct is returned as expected
+func Test_setRegInfo(t *testing.T) {
+	initMetadata() // Used from metadata_test.go
+
+	svc := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_use_elbv2_endpoint":  "false",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+		Name: "app",
+	}
+
+	awsInfo := eureka.AmazonMetadataType{
+		PublicHostname: "dns-name",
+		HostName:       "dns-name",
+		InstanceID:     "endpoint",
+	}
+
+	dcInfo := eureka.DataCenterInfo{
+		Name:     eureka.Amazon,
+		Metadata: awsInfo,
+	}
+
+	reg := eureka.Instance{
+		DataCenterInfo: dcInfo,
+		Port:           5001,
+		IPAddr:         "4.3.2.1",
+		App:            "app",
+		VipAddress:     "4.3.2.1",
+		HostName:       "hostname",
+	}
+
+	// Init LB info cache
+	lbCache["init1_5001"] = &LBInfo{
+		DNSName: "lb-dnsname",
+		Port:    9001,
+	}
+
+	wantedAwsInfo := eureka.AmazonMetadataType{
+		PublicHostname: "lb-dnsname",
+		HostName:       "lb-dnsname",
+		InstanceID:     "lb-dnsname_9001",
+	}
+	wantedDCInfo := eureka.DataCenterInfo{
+		Name:     eureka.Amazon,
+		Metadata: wantedAwsInfo,
+	}
+
+	wanted := eureka.Instance{
+		DataCenterInfo: wantedDCInfo,
+		Port:           9001,
+		App:            svc.Name,
+		IPAddr:         "lb-dnsname",
+		VipAddress:     "lb-dnsname",
+		HostName:       "lb-dnsname",
+	}
+
+	type args struct {
+		service      *bridge.Service
+		registration *eureka.Instance
+	}
+	tests := []struct {
+		name string
+		args args
+		want *eureka.Instance
+	}{
+		{
+			name: "Should match data",
+			args: args{service: &svc, registration: &reg},
+			want: &wanted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := setRegInfo(tt.args.service, tt.args.registration, true)
+			val := got.Metadata.GetMap()["is-elbv2"]
+			if val != "true" {
+				t.Errorf("setRegInfo() = %+v, \n Wanted is-elbv2=true in metadata, was %+v", got, val)
+			}
+			//Overwrite metadata before comparing data structure - we've directly checked the flag we are looking for
+			got.Metadata = eureka.InstanceMetadata{}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("setRegInfo() = %+v, \nwant %+v\n", got, tt.want)
+			}
+		})
+	}
+}

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -19,6 +19,9 @@ type Metadata struct {
 	Region           string
 }
 
+var metadataCache *Metadata
+var inited = false
+
 // Test retrieval of metadata key and print an error if not, returning empty string
 func getDataOrFail(svc interfaces.EC2MetadataGetter, key string) string {
 	val, err := svc.GetMetadata(key)
@@ -31,12 +34,22 @@ func getDataOrFail(svc interfaces.EC2MetadataGetter, key string) string {
 
 // GetMetadata - retrieve metadata from AWS about the current host, using IAM role
 func GetMetadata() *Metadata {
+
+	if inited {
+		log.Println("Returning cached metadata.")
+		return metadataCache
+	}
+
 	sess, err := session.NewSession()
 	if err != nil {
 		fmt.Printf("Unable to connect to the EC2 metadata service: %s\n", err)
 	}
 	svc := ec2metadata.New(sess)
-	return retrieveMetadata(svc)
+
+	metadataCache = retrieveMetadata(svc)
+	inited = true
+
+	return metadataCache
 }
 
 // RetrieveMetadata - retrieve metadata from AWS about the current host, using IAM role

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/gliderlabs/registrator/interfaces"
 )
 
 type Metadata struct {
@@ -18,15 +19,8 @@ type Metadata struct {
 	Region           string
 }
 
-// IEC2Metadata Interface to help with test mocking
-type IEC2Metadata interface {
-	GetMetadata(string) (string, error)
-	Available() bool
-	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
-}
-
 // Test retrieval of metadata key and print an error if not, returning empty string
-func getDataOrFail(svc IEC2Metadata, key string) string {
+func getDataOrFail(svc interfaces.EC2MetadataGetter, key string) string {
 	val, err := svc.GetMetadata(key)
 	if err != nil {
 		log.Printf("Unable to retrieve %s from the EC2 instance: %s\n", key, err)
@@ -46,7 +40,7 @@ func GetMetadata() *Metadata {
 }
 
 // RetrieveMetadata - retrieve metadata from AWS about the current host, using IAM role
-func retrieveMetadata(svc IEC2Metadata) *Metadata {
+func retrieveMetadata(svc interfaces.EC2MetadataGetter) *Metadata {
 	log.Println("Attempting to retrieve AWS metadata.")
 
 	m := new(Metadata)

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -1,28 +1,6 @@
 package interfaces
 
-import (
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	fargo "github.com/hudl/fargo"
-)
-
-// InstanceData - Type to wrap fargo.Instance for testing
-type InstanceData struct {
-	fargo.Instance
-	// SetMetadataString(string, string)
-	// Id() string
-}
-
-// RegistrationData - Wrap registration instance to facilitate testing
-type RegistrationData struct {
-	Instance InstanceData
-}
-
-// EurekaConnector - Wraps fargo.EurekaConnection to facilitate testing
-type EurekaConnector interface {
-	HeartBeatInstance(*InstanceData)
-	GetApp(string)
-	DeregisterInstance(*InstanceData)
-}
+import "github.com/aws/aws-sdk-go/aws/ec2metadata"
 
 // EC2MetadataGetter Interface to help with test mocking
 type EC2MetadataGetter interface {

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -1,0 +1,32 @@
+package interfaces
+
+import (
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	fargo "github.com/hudl/fargo"
+)
+
+// InstanceData - Type to wrap fargo.Instance for testing
+type InstanceData struct {
+	fargo.Instance
+	// SetMetadataString(string, string)
+	// Id() string
+}
+
+// RegistrationData - Wrap registration instance to facilitate testing
+type RegistrationData struct {
+	Instance InstanceData
+}
+
+// EurekaConnector - Wraps fargo.EurekaConnection to facilitate testing
+type EurekaConnector interface {
+	HeartBeatInstance(*InstanceData)
+	GetApp(string)
+	DeregisterInstance(*InstanceData)
+}
+
+// EC2MetadataGetter Interface to help with test mocking
+type EC2MetadataGetter interface {
+	GetMetadata(string) (string, error)
+	Available() bool
+	GetInstanceIdentityDocument() (ec2metadata.EC2InstanceIdentityDocument, error)
+}


### PR DESCRIPTION
This PR does a couple of things:

1. Add unit tests for ELBs.
2. Change/improve metadata unit tests
3. Add some basic caching, so AWS metadata is cached at startup (specific to host)
4. Add a basic cache for ELBv2, so the AWS API will only be used when adding new containers, and not for heartbeats.
