### PR TITLE
Fix ELBv2 port, and target group retrieval

### DIFF
--- a/aws/elb.go
+++ b/aws/elb.go
@@ -118,7 +118,6 @@ func getELBV2ForContainer(instanceID string, port int64, useCache bool) (lbinfo 
 
 			for _, thd := range tarH.TargetHealthDescriptions {
 				if *thd.Target.Port == port && *thd.Target.Id == instanceID {
-					log.Printf("Identitified TG: %+v", thd)
 					lbArns = tg.LoadBalancerArns
 					tgArn = *tg.TargetGroupArn
 					break
@@ -141,7 +140,6 @@ func getELBV2ForContainer(instanceID string, port int64, useCache bool) (lbinfo 
 	}
 	for _, listener := range lnrData.Listeners {
 		for _, act := range listener.DefaultActions {
-			log.Printf("Listener: %+v", act)
 			if *act.TargetGroupArn == tgArn {
 				log.Printf("Found matching listener: %v", *listener.ListenerArn)
 				lbPort = listener.Port

--- a/aws/metadata.go
+++ b/aws/metadata.go
@@ -22,6 +22,12 @@ type Metadata struct {
 var metadataCache *Metadata
 var inited = false
 
+// SetMetadata - Set the metadata and init - mainly for testing
+func SetMetadata(md *Metadata) {
+	metadataCache = md
+	inited = true
+}
+
 // Test retrieval of metadata key and print an error if not, returning empty string
 func getDataOrFail(svc interfaces.EC2MetadataGetter, key string) string {
 	val, err := svc.GetMetadata(key)


### PR DESCRIPTION
1. Fix ELBv2 port retrieval, by instead returning the listener port on the load balancer (was returning the target group port, which is irrelevant)

2. Also, fix missing paging over target groups by creating two new helper functions.  Previously, only the first 400 target groups were being retrieved.  Unfortunately there doesn't seem to be a more efficient way to do this than looping through all target groups, though suggestions are welcome - API docs are here: https://docs.aws.amazon.com/sdk-for-go/api/service/elbv2/#DescribeTargetGroupsInput