### PR TITLE
Fix ELB deregistration

### DIFF
--- a/aws/elb.go
+++ b/aws/elb.go
@@ -225,6 +225,7 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance, useCache
 	elbReg.HostName = elbMetadata.DNSName
 	elbReg.DataCenterInfo.Name = eureka.Amazon
 	elbReg.SetMetadataString("is-elbv2", "true")
+	elbReg.Status = eureka.UP
 	return elbReg
 }
 
@@ -246,7 +247,7 @@ func RegisterELBv2(service *bridge.Service, registration *eureka.Instance, clien
 func DeregisterELBv2(service *bridge.Service, albEndpoint string, client eureka.EurekaConnection) {
 	if CheckELBFlags(service) {
 		// Check if there are any containers around with this ALB still attached
-		log.Printf("Found ELBv2 flags, will check if it needs to be deregistered too, for: %s:%v\n", albEndpoint)
+		log.Printf("Found ELBv2 flags, will check if it needs to be deregistered too, for: %v\n", albEndpoint)
 		appName := "CONTAINER_" + service.Name
 
 		app, err := client.GetApp(appName)

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -69,10 +69,10 @@ func getTargetGroupsPage(svc *elbv2.ELBV2, marker *string) (*elbv2.DescribeTarge
 // Pass it the instanceID for the docker host, and the the host port to lookup the associated ELB.
 // useCache parameter, if true, will retrieve ELBv2 details from memory, rather than calling AWS.
 // this is only really safe to use for heartbeat calls, as details can change dynamically
-func getELBV2ForContainer(instanceID string, port int64, useCache bool) (lbinfo *LBInfo, err error) {
+func getELBV2ForContainer(containerID string, instanceID string, port int64, useCache bool) (lbinfo *LBInfo, err error) {
 
 	// Retrieve from basic cache (for heartbeats)
-	cacheKey := instanceID + "_" + strconv.FormatInt(port, 10)
+	cacheKey := instanceID + "_" + containerID
 	if val, ok := lbCache[cacheKey]; ok && useCache {
 		log.Println("Retrieving value from cache.")
 		return val, nil
@@ -196,7 +196,7 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance, useCache
 
 	awsMetadata := GetMetadata()
 
-	elbMetadata, err := getELBV2ForContainer(awsMetadata.InstanceID, int64(registration.Port), useCache)
+	elbMetadata, err := getELBV2ForContainer(service.Origin.ContainerID, awsMetadata.InstanceID, int64(registration.Port), useCache)
 
 	if err != nil {
 		log.Printf("Unable to find associated ELBv2 for: %s, Error: %s\n", registration.HostName, err)

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -102,7 +102,7 @@ func getELBV2ForContainer(instanceID string, port int64, useCache bool) (lbinfo 
 	}
 
 	// Check each target group's target list for a matching port and instanceID
-	// Assumption: that that there is only one LB for the target group (though the data structure allows more)
+	// TODO Assumption: that that there is only one LB for the target group (though the data structure allows more)
 	for _, tgs := range tgslice {
 		for _, tg := range tgs.TargetGroups {
 
@@ -127,6 +127,11 @@ func getELBV2ForContainer(instanceID string, port int64, useCache bool) (lbinfo 
 		if lbArns != nil && tgArn != "" {
 			break
 		}
+	}
+
+	if err != nil || lbArns == nil {
+		message := fmt.Errorf("failed to retrieve load balancer ARN")
+		return nil, message
 	}
 
 	// Loop through the load balancer listeners to get the listener port for the target group

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -250,6 +250,11 @@ func DeregisterELBv2(service *bridge.Service, albEndpoint string, client eureka.
 		appName := "CONTAINER_" + service.Name
 
 		app, err := client.GetApp(appName)
+		if err != nil {
+			log.Printf("Unable to retrieve app metadata for %s: %s\n", appName, err)
+			return
+		}
+
 		if app != nil {
 			for _, instance := range app.Instances {
 				val, err := instance.Metadata.GetString("elbv2_endpoint")
@@ -258,9 +263,6 @@ func DeregisterELBv2(service *bridge.Service, albEndpoint string, client eureka.
 					return
 				}
 			}
-		}
-		if err != nil {
-			log.Printf("Unable to retrieve app metadata for %s: %s\n", appName, err)
 		}
 
 		if app == nil {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -272,7 +272,7 @@ func DeregisterELBv2(service *bridge.Service, albEndpoint string, client eureka.
 
 		if app != nil {
 			for _, instance := range app.Instances {
-				val, err := instance.Metadata.GetString("elbv2_endpoint")
+				val, err := instance.Metadata.GetString("elbv2-endpoint")
 				if err == nil && val == albEndpoint {
 					log.Printf("Eureka entry still present for one or more ALB linked containers: %s\n", val)
 					delete(registrations, service.Origin.ContainerID)

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -8,8 +8,8 @@ import (
 	eureka "github.com/hudl/fargo"
 )
 
-// Test_getELBV2ForContainer - Test expected values are returned
-func Test_getELBV2ForContainer(t *testing.T) {
+// Test_GetELBV2ForContainer - Test expected values are returned
+func Test_GetELBV2ForContainer(t *testing.T) {
 
 	// Setup cache
 	lbWant := LBInfo{
@@ -39,13 +39,13 @@ func Test_getELBV2ForContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLbinfo, err := getELBV2ForContainer(tt.args.containerID, tt.args.instanceID, tt.args.port, true)
+			gotLbinfo, err := GetELBV2ForContainer(tt.args.containerID, tt.args.instanceID, tt.args.port, true)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getELBV2ForContainer() error = %+v, wantErr %+v", err, tt.wantErr)
+				t.Errorf("GetELBV2ForContainer() error = %+v, wantErr %+v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(gotLbinfo, tt.wantLbinfo) {
-				t.Errorf("getELBV2ForContainer() = %+v, want %+v", gotLbinfo, tt.wantLbinfo)
+				t.Errorf("GetELBV2ForContainer() = %+v, want %+v", gotLbinfo, tt.wantLbinfo)
 			}
 		})
 	}

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -16,11 +16,12 @@ func Test_getELBV2ForContainer(t *testing.T) {
 		DNSName: "",
 		Port:    int64(1234),
 	}
-	lbCache["instance-123_1234"] = &lbWant
+	lbCache["instance-123_123123412"] = &lbWant
 
 	type args struct {
-		instanceID string
-		port       int64
+		containerID string
+		instanceID  string
+		port        int64
 	}
 	tests := []struct {
 		name       string
@@ -30,7 +31,7 @@ func Test_getELBV2ForContainer(t *testing.T) {
 	}{
 		{
 			name:       "should match",
-			args:       args{instanceID: "instance-123", port: int64(1234)},
+			args:       args{containerID: "123123412", instanceID: "instance-123", port: int64(1234)},
 			wantErr:    false,
 			wantLbinfo: &lbWant,
 		},
@@ -38,7 +39,7 @@ func Test_getELBV2ForContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLbinfo, err := getELBV2ForContainer(tt.args.instanceID, tt.args.port, true)
+			gotLbinfo, err := getELBV2ForContainer(tt.args.containerID, tt.args.instanceID, tt.args.port, true)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getELBV2ForContainer() error = %+v, wantErr %+v", err, tt.wantErr)
 				return
@@ -117,6 +118,9 @@ func Test_setRegInfo(t *testing.T) {
 			"eureka_datacenterinfo_name": "AMAZON",
 		},
 		Name: "app",
+		Origin: bridge.ServicePort{
+			ContainerID: "123123412",
+		},
 	}
 
 	awsInfo := eureka.AmazonMetadataType{
@@ -140,7 +144,7 @@ func Test_setRegInfo(t *testing.T) {
 	}
 
 	// Init LB info cache
-	lbCache["init1_5001"] = &LBInfo{
+	lbCache["init1_123123412"] = &LBInfo{
 		DNSName: "lb-dnsname",
 		Port:    9001,
 	}
@@ -162,6 +166,7 @@ func Test_setRegInfo(t *testing.T) {
 		IPAddr:         "lb-dnsname",
 		VipAddress:     "lb-dnsname",
 		HostName:       "lb-dnsname",
+		Status:         eureka.UP,
 	}
 
 	type args struct {

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -16,7 +16,7 @@ func Test_getELBV2ForContainer(t *testing.T) {
 		DNSName: "",
 		Port:    int64(1234),
 	}
-	lbCache["instance-123_123123412"] = &lbWant
+	lbCache["123123412"] = &lbWant
 
 	type args struct {
 		containerID string
@@ -144,7 +144,7 @@ func Test_setRegInfo(t *testing.T) {
 	}
 
 	// Init LB info cache
-	lbCache["init1_123123412"] = &LBInfo{
+	lbCache["123123412"] = &LBInfo{
 		DNSName: "lb-dnsname",
 		Port:    9001,
 	}

--- a/aws/metadata_test.go
+++ b/aws/metadata_test.go
@@ -29,9 +29,7 @@ func initMetadata() {
 		Region:           "ius-east-1",
 	}
 
-	metadataCache = md
-	inited = true
-
+	SetMetadata(md)
 }
 
 var _ interfaces.EC2MetadataGetter = (*testMetadata)(nil)

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -182,13 +182,7 @@ func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	registration.App = service.Name
 	var albEndpoint string
 	if aws.CheckELBFlags(service) {
-		var ok bool
-		t, _ := instanceInformation(service).Metadata.GetMap()["elbv2-endpoint"]
-		albEndpoint, ok = t.(string)
-		if !ok {
-			log.Printf("Failed to retrieve endpoint for ELBv2!")
-		}
-
+		albEndpoint, _ = instanceInformation(service).Metadata.GetString("elbv2-endpoint")
 		registration.App = "CONTAINER_" + service.Name
 	}
 	log.Println("Deregistering ", registration.HostName)

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -182,7 +182,8 @@ func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	registration.App = service.Name
 	var albEndpoint string
 	if aws.CheckELBFlags(service) {
-		albEndpoint, _ = instanceInformation(service).Metadata.GetString("elbv2-endpoint")
+		albEndpoint, _ = instanceInformation(service).Metadata.GetMap()["elbv2-endpoint"]
+		registration.App = "CONTAINER_" + service.Name
 	}
 	log.Println("Deregistering ", registration.HostName)
 	instance := r.client.DeregisterInstance(registration)

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -182,7 +182,13 @@ func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	registration.App = service.Name
 	var albEndpoint string
 	if aws.CheckELBFlags(service) {
-		albEndpoint, _ = instanceInformation(service).Metadata.GetMap()["elbv2-endpoint"]
+		var ok bool
+		t, _ := instanceInformation(service).Metadata.GetMap()["elbv2-endpoint"]
+		albEndpoint, ok = t.(string)
+		if !ok {
+			log.Printf("Failed to retrieve endpoint for ELBv2!")
+		}
+
 		registration.App = "CONTAINER_" + service.Name
 	}
 	log.Println("Deregistering ", registration.HostName)

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -186,7 +186,7 @@ func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	}
 	log.Println("Deregistering ", registration.HostName)
 	instance := r.client.DeregisterInstance(registration)
-	aws.DeregisterELBv2(service, service.Name, int64(registration.Port), r.client)
+	aws.DeregisterELBv2(service, registration.Metadata.GetString("elbv2-endpoint"), int64(registration.Port), r.client)
 	return instance
 }
 

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -179,14 +179,14 @@ func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	registration := new(fargo.Instance)
 	registration.HostName = service.IP + "_" + strconv.Itoa(service.Port)
 	registration.UniqueID = uniqueID
+	registration.App = service.Name
+	var albEndpoint string
 	if aws.CheckELBFlags(service) {
-		registration.App = "CONTAINER_" + service.Name
-	} else {
-		registration.App = service.Name
+		albEndpoint, _ = instanceInformation(service).Metadata.GetString("elbv2-endpoint")
 	}
 	log.Println("Deregistering ", registration.HostName)
 	instance := r.client.DeregisterInstance(registration)
-	aws.DeregisterELBv2(service, registration.Metadata.GetString("elbv2-endpoint"), int64(registration.Port), r.client)
+	aws.DeregisterELBv2(service, albEndpoint, r.client)
 	return instance
 }
 


### PR DESCRIPTION
ELBv2 was not being correctly deregistered as intended.  This fixes that problem, and adds a small fix to prevent a possible panic if a load balancer is not found during registration.

