### PR TITLE
Add explicit ELBv2 options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM gliderlabs/alpine
 ENTRYPOINT ["/bin/registrator"]
 
 COPY . /go/src/github.com/gliderlabs/registrator
@@ -8,4 +8,4 @@ RUN apk-install -t build-deps build-base go git mercurial \
 	&& go get \
 	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
 	&& rm -rf /go \
-	&& apk del --purge build-deps
+	&& apk del --purge build-deps git mercurial

--- a/Dockerfile.race
+++ b/Dockerfile.race
@@ -1,0 +1,9 @@
+FROM golang:1.7
+ENTRYPOINT ["/bin/registrator"]
+
+COPY . /go/src/github.com/gliderlabs/registrator
+RUN cd /go/src/github.com/gliderlabs/registrator \
+	&& export GOPATH=/go \
+	&& go get \
+	&& go build -race -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
+	&& rm -rf /go \

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -192,7 +192,7 @@ func RemoveLBCache(containerID string) {
 }
 
 // CheckELBFlags - Helper function to check if the correct config flags are set to use ELBs
-// We accept two possible configurations here - either eureka_use_elbv2_endpoint can be set,
+// We accept two possible configurations here - either eureka_lookup_elbv2_endpoint can be set,
 // for automatic lookup, or eureka_elbv2_hostname and eureka_elbv2_port can be set manually
 // to avoid the 10-20s wait for lookups
 func CheckELBFlags(service *bridge.Service) bool {
@@ -211,16 +211,16 @@ func CheckELBFlags(service *bridge.Service) bool {
 		useLookup = true
 	}
 
-	if service.Attrs["eureka_use_elbv2_endpoint"] != "" {
-		v, err := strconv.ParseBool(service.Attrs["eureka_use_elbv2_endpoint"])
+	if service.Attrs["eureka_lookup_elbv2_endpoint"] != "" {
+		v, err := strconv.ParseBool(service.Attrs["eureka_lookup_elbv2_endpoint"])
 		if err != nil {
-			log.Printf("eureka: eureka_use_elbv2_endpoint must be valid boolean, was %v : %s", v, err)
+			log.Printf("eureka: eureka_lookup_elbv2_endpoint must be valid boolean, was %v : %s", v, err)
 			useLookup = false
 		}
 		useLookup = v
 	}
 
-	if ((hasExplicit && useLookup) || useLookup) && isAws {
+	if (hasExplicit || useLookup) && isAws {
 		return true
 	}
 	return false

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -82,6 +82,7 @@ func GetELBV2ForContainer(containerID string, instanceID string, port int64, use
 	}
 
 	// We need to have small random wait here, because it takes a little while for new containers to appear in target groups
+	// to avoid any wait, the endpoints can be specified manually as eureka_elbv2_hostname and eureka_elbv2_port vars
 	rand.NewSource(time.Now().UnixNano())
 	period := time.Second * time.Duration(rand.Intn(10)+20)
 	time.Sleep(period)
@@ -191,14 +192,36 @@ func RemoveLBCache(containerID string) {
 }
 
 // CheckELBFlags - Helper function to check if the correct config flags are set to use ELBs
+// We accept two possible configurations here - either eureka_use_elbv2_endpoint can be set,
+// for automatic lookup, or eureka_elbv2_hostname and eureka_elbv2_port can be set manually
+// to avoid the 10-20s wait for lookups
 func CheckELBFlags(service *bridge.Service) bool {
-	if service.Attrs["eureka_use_elbv2_endpoint"] != "" && service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn {
+
+	isAws := service.Attrs["eureka_datacenterinfo_name"] != eureka.MyOwn
+	var hasExplicit bool
+	var useLookup bool
+
+	if service.Attrs["eureka_elbv2_hostname"] != "" && service.Attrs["eureka_elbv2_port"] != "" {
+		v, err := strconv.ParseUint(service.Attrs["eureka_elbv2_port"], 10, 16)
+		if err != nil {
+			log.Printf("eureka: eureka_elbv2_port must be valid 16-bit unsigned int, was %v : %s", v, err)
+			hasExplicit = false
+		}
+		hasExplicit = true
+		useLookup = true
+	}
+
+	if service.Attrs["eureka_use_elbv2_endpoint"] != "" {
 		v, err := strconv.ParseBool(service.Attrs["eureka_use_elbv2_endpoint"])
 		if err != nil {
 			log.Printf("eureka: eureka_use_elbv2_endpoint must be valid boolean, was %v : %s", v, err)
-			return false
+			useLookup = false
 		}
-		return v
+		useLookup = v
+	}
+
+	if ((hasExplicit && useLookup) || useLookup) && isAws {
+		return true
 	}
 	return false
 }
@@ -208,22 +231,32 @@ func CheckELBFlags(service *bridge.Service) bool {
 func setRegInfo(service *bridge.Service, registration *eureka.Instance, useCache bool) *eureka.Instance {
 
 	awsMetadata := GetMetadata()
+	var elbEndpoint string
 
-	elbMetadata, err := GetELBV2ForContainer(service.Origin.ContainerID, awsMetadata.InstanceID, int64(registration.Port), useCache)
+	// We've been given the ELB endpoint, so use this
+	if service.Attrs["eureka_elbv2_hostname"] != "" && service.Attrs["eureka_elbv2_port"] != "" {
+		log.Printf("Found ELBv2 hostname=%v and port=%v options, using these.", service.Attrs["eureka_elbv2_hostname"], service.Attrs["eureka_elbv2_port"])
+		registration.Port, _ = strconv.Atoi(service.Attrs["eureka_elbv2_port"])
+		registration.IPAddr = service.Attrs["eureka_elbv2_hostname"]
+		elbEndpoint = service.Attrs["eureka_elbv2_hostname"] + "_" + service.Attrs["eureka_elbv2_port"]
 
-	if err != nil {
-		log.Printf("Unable to find associated ELBv2 for: %s, Error: %s\n", registration.HostName, err)
-		return nil
+	} else {
+		// We don't have the ELB endpoint, so look it up.
+		elbMetadata, err := GetELBV2ForContainer(service.Origin.ContainerID, awsMetadata.InstanceID, int64(registration.Port), useCache)
+
+		if err != nil {
+			log.Printf("Unable to find associated ELBv2 for: %s, Error: %s\n", registration.HostName, err)
+			return nil
+		}
+
+		elbStrPort := strconv.FormatInt(elbMetadata.Port, 10)
+		elbEndpoint = elbMetadata.DNSName + "_" + elbStrPort
+		registration.Port = int(elbMetadata.Port)
+		registration.IPAddr = elbMetadata.DNSName
 	}
-
-	elbStrPort := strconv.FormatInt(elbMetadata.Port, 10)
-	elbEndpoint := elbMetadata.DNSName + "_" + elbStrPort
 
 	registration.SetMetadataString("has-elbv2", "true")
 	registration.SetMetadataString("elbv2-endpoint", elbEndpoint)
-
-	registration.Port = int(elbMetadata.Port)
-	registration.IPAddr = elbMetadata.DNSName
 	registration.VipAddress = registration.IPAddr
 	return registration
 }

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -57,15 +57,15 @@ func TestCheckELBFlags(t *testing.T) {
 
 	svcFalse := bridge.Service{
 		Attrs: map[string]string{
-			"eureka_use_elbv2_endpoint":  "false",
-			"eureka_datacenterinfo_name": "AMAZON",
+			"eureka_lookup_elbv2_endpoint": "false",
+			"eureka_datacenterinfo_name":   "AMAZON",
 		},
 	}
 
 	svcFalse2 := bridge.Service{
 		Attrs: map[string]string{
-			"eureka_use_elbv2_endpoint":  "true",
-			"eureka_datacenterinfo_name": "MyOwn",
+			"eureka_lookup_elbv2_endpoint": "true",
+			"eureka_datacenterinfo_name":   "MyOwn",
 		},
 	}
 
@@ -76,19 +76,10 @@ func TestCheckELBFlags(t *testing.T) {
 		},
 	}
 
-	svcFalse4 := bridge.Service{
-		Attrs: map[string]string{
-			"eureka_elbv2_hostname":      "my-name",
-			"eureka_use_elbv2_endpoint":  "false",
-			"eureka_elbv2_port":          "1234",
-			"eureka_datacenterinfo_name": "AMAZON",
-		},
-	}
-
 	svcTrue := bridge.Service{
 		Attrs: map[string]string{
-			"eureka_use_elbv2_endpoint":  "true",
-			"eureka_datacenterinfo_name": "AMAZON",
+			"eureka_lookup_elbv2_endpoint": "true",
+			"eureka_datacenterinfo_name":   "AMAZON",
 		},
 	}
 
@@ -102,10 +93,19 @@ func TestCheckELBFlags(t *testing.T) {
 
 	svcTrue3 := bridge.Service{
 		Attrs: map[string]string{
-			"eureka_elbv2_hostname":      "my-name",
-			"eureka_use_elbv2_endpoint":  "true",
-			"eureka_elbv2_port":          "1234",
-			"eureka_datacenterinfo_name": "AMAZON",
+			"eureka_elbv2_hostname":        "my-name",
+			"eureka_lookup_elbv2_endpoint": "true",
+			"eureka_elbv2_port":            "1234",
+			"eureka_datacenterinfo_name":   "AMAZON",
+		},
+	}
+
+	svcTrue4 := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_elbv2_hostname":        "my-name",
+			"eureka_lookup_elbv2_endpoint": "false",
+			"eureka_elbv2_port":            "1234",
+			"eureka_datacenterinfo_name":   "AMAZON",
 		},
 	}
 
@@ -118,7 +118,7 @@ func TestCheckELBFlags(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "use endpoint set to false",
+			name: "use lookup set to false",
 			args: args{service: &svcFalse},
 			want: false,
 		},
@@ -133,12 +133,7 @@ func TestCheckELBFlags(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "elb hostname, and port are set, but endpoint is false",
-			args: args{service: &svcFalse4},
-			want: false,
-		},
-		{
-			name: "elb endpoint set to true",
+			name: "elb lookup set to true",
 			args: args{service: &svcTrue},
 			want: true,
 		},
@@ -148,8 +143,13 @@ func TestCheckELBFlags(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "elb hostname and port are set, as is use endpoint",
+			name: "elb hostname and port are set, as is lookup",
 			args: args{service: &svcTrue3},
+			want: true,
+		},
+		{
+			name: "elb hostname, and port are set, lookup is false",
+			args: args{service: &svcTrue4},
 			want: true,
 		},
 	}
@@ -168,8 +168,8 @@ func Test_setRegInfo(t *testing.T) {
 
 	svc := bridge.Service{
 		Attrs: map[string]string{
-			"eureka_use_elbv2_endpoint":  "false",
-			"eureka_datacenterinfo_name": "AMAZON",
+			"eureka_lookup_elbv2_endpoint": "false",
+			"eureka_datacenterinfo_name":   "AMAZON",
 		},
 		Name: "app",
 		Origin: bridge.ServicePort{
@@ -267,10 +267,10 @@ func Test_setRegInfoExplicitEndpoint(t *testing.T) {
 
 	svc := bridge.Service{
 		Attrs: map[string]string{
-			"eureka_use_elbv2_endpoint":  "false",
-			"eureka_elbv2_hostname":      "hostname-i-set",
-			"eureka_elbv2_port":          "65535",
-			"eureka_datacenterinfo_name": "AMAZON",
+			"eureka_lookup_elbv2_endpoint": "false",
+			"eureka_elbv2_hostname":        "hostname-i-set",
+			"eureka_elbv2_port":            "65535",
+			"eureka_datacenterinfo_name":   "AMAZON",
 		},
 		Name: "app",
 		Origin: bridge.ServicePort{

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/gliderlabs/registrator/bridge"
@@ -68,9 +69,42 @@ func TestCheckELBFlags(t *testing.T) {
 		},
 	}
 
+	svcFalse3 := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_elbv2_hostname":      "my-name",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+	}
+
+	svcFalse4 := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_elbv2_hostname":      "my-name",
+			"eureka_use_elbv2_endpoint":  "false",
+			"eureka_elbv2_port":          "1234",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+	}
+
 	svcTrue := bridge.Service{
 		Attrs: map[string]string{
 			"eureka_use_elbv2_endpoint":  "true",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+	}
+
+	svcTrue2 := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_elbv2_hostname":      "my-name",
+			"eureka_elbv2_port":          "1234",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+	}
+
+	svcTrue3 := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_elbv2_hostname":      "my-name",
+			"eureka_use_elbv2_endpoint":  "true",
+			"eureka_elbv2_port":          "1234",
 			"eureka_datacenterinfo_name": "AMAZON",
 		},
 	}
@@ -84,18 +118,38 @@ func TestCheckELBFlags(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "should be false",
+			name: "use endpoint set to false",
 			args: args{service: &svcFalse},
 			want: false,
 		},
 		{
-			name: "should be false again",
+			name: "datacentre is set to MyOwn",
 			args: args{service: &svcFalse2},
 			want: false,
 		},
 		{
-			name: "should be true",
+			name: "elb hostname, but not port is set",
+			args: args{service: &svcFalse3},
+			want: false,
+		},
+		{
+			name: "elb hostname, and port are set, but endpoint is false",
+			args: args{service: &svcFalse4},
+			want: false,
+		},
+		{
+			name: "elb endpoint set to true",
 			args: args{service: &svcTrue},
+			want: true,
+		},
+		{
+			name: "elb hostname and port are set",
+			args: args{service: &svcTrue2},
+			want: true,
+		},
+		{
+			name: "elb hostname and port are set, as is use endpoint",
+			args: args{service: &svcTrue3},
 			want: true,
 		},
 	}
@@ -162,11 +216,11 @@ func Test_setRegInfo(t *testing.T) {
 
 	wanted := eureka.Instance{
 		DataCenterInfo: wantedDCInfo,
-		Port:           9001,
+		Port:           int(lbCache["123123412"].Port),
 		App:            svc.Name,
-		IPAddr:         "lb-dnsname",
-		VipAddress:     "lb-dnsname",
-		HostName:       "hostname_identifier",
+		IPAddr:         lbCache["123123412"].DNSName,
+		VipAddress:     lbCache["123123412"].DNSName,
+		HostName:       reg.HostName,
 		Status:         eureka.UP,
 	}
 
@@ -193,8 +247,9 @@ func Test_setRegInfo(t *testing.T) {
 				t.Errorf("setRegInfo() = %+v, \n Wanted has-elbv2=true in metadata, was %+v", got, val)
 			}
 			val2 := got.Metadata.GetMap()["elbv2-endpoint"]
-			if val2 != "lb-dnsname_9001" {
-				t.Errorf("setRegInfo() = %+v, \n Wanted elbv2-endpoint=lb-dnsname_9001 in metadata, was %+v", got, val)
+			wantVal := lbCache["123123412"].DNSName + "_" + strconv.Itoa(int(lbCache["123123412"].Port))
+			if val2 != wantVal {
+				t.Errorf("setRegInfo() = %+v, \n Wanted elbv2-endpoint=%v in metadata, was %+v", got, wantVal, val)
 			}
 			//Overwrite metadata before comparing data structure - we've directly checked the flag we are looking for
 			got.Metadata = eureka.InstanceMetadata{}
@@ -203,4 +258,108 @@ func Test_setRegInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_setRegInfoExplicitEndpoint - Test that registration struct is returned as expected when you set the host and port
+// and that they are used rather than the load balancer lookup
+func Test_setRegInfoExplicitEndpoint(t *testing.T) {
+	initMetadata() // Used from metadata_test.go
+
+	svc := bridge.Service{
+		Attrs: map[string]string{
+			"eureka_use_elbv2_endpoint":  "false",
+			"eureka_elbv2_hostname":      "hostname-i-set",
+			"eureka_elbv2_port":          "65535",
+			"eureka_datacenterinfo_name": "AMAZON",
+		},
+		Name: "app",
+		Origin: bridge.ServicePort{
+			ContainerID: "123123412",
+		},
+	}
+
+	awsInfo := eureka.AmazonMetadataType{
+		PublicHostname: "dns-name",
+		HostName:       "dns-name",
+		InstanceID:     "endpoint",
+	}
+
+	dcInfo := eureka.DataCenterInfo{
+		Name:     eureka.Amazon,
+		Metadata: awsInfo,
+	}
+
+	reg := eureka.Instance{
+		DataCenterInfo: dcInfo,
+		Port:           5001,
+		IPAddr:         "4.3.2.1",
+		App:            "app",
+		VipAddress:     "4.3.2.1",
+		HostName:       "hostname_identifier",
+		Status:         eureka.UP,
+	}
+
+	// Init LB info cache
+	// if things are working correctly, this won't be used for this test
+	lbCache["123123412"] = &LBInfo{
+		DNSName: "lb-dnsname",
+		Port:    9001,
+	}
+
+	wantedAwsInfo := eureka.AmazonMetadataType{
+		PublicHostname: "dns-name",
+		HostName:       "dns-name",
+		InstanceID:     "endpoint",
+	}
+	wantedDCInfo := eureka.DataCenterInfo{
+		Name:     eureka.Amazon,
+		Metadata: wantedAwsInfo,
+	}
+
+	expectedPort, _ := strconv.Atoi(svc.Attrs["eureka_elbv2_port"])
+	wanted := eureka.Instance{
+		DataCenterInfo: wantedDCInfo,
+		Port:           expectedPort,
+		App:            svc.Name,
+		IPAddr:         svc.Attrs["eureka_elbv2_hostname"],
+		VipAddress:     svc.Attrs["eureka_elbv2_hostname"],
+		HostName:       reg.HostName,
+		Status:         eureka.UP,
+	}
+
+	type args struct {
+		service      *bridge.Service
+		registration *eureka.Instance
+	}
+	tests := []struct {
+		name string
+		args args
+		want *eureka.Instance
+	}{
+		{
+			name: "Should match data",
+			args: args{service: &svc, registration: &reg},
+			want: &wanted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := setRegInfo(tt.args.service, tt.args.registration, true)
+			val := got.Metadata.GetMap()["has-elbv2"]
+			if val != "true" {
+				t.Errorf("setRegInfo() = %+v, \n Wanted has-elbv2=true in metadata, was %+v", got, val)
+			}
+			val2 := got.Metadata.GetMap()["elbv2-endpoint"]
+			wantVal := svc.Attrs["eureka_elbv2_hostname"] + "_" + svc.Attrs["eureka_elbv2_port"]
+			if val2 != wantVal {
+				t.Errorf("setRegInfo() = %+v, \n Wanted elbv2-endpoint=%v in metadata, was %+v", got, wantVal, val2)
+			}
+			//Overwrite metadata before comparing data structure - we've directly checked the flag we are looking for
+			got.Metadata = eureka.InstanceMetadata{}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("setRegInfo() = %+v, \nwant %+v\n", got, tt.want)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
This PR tries to work around some of the sleepiness problems with ELB registration.

This PR adds two new options for container labels/variables:

- `SERVICE_EUREKA_ELBV2_HOSTNAME` 
- `SERVICE_EUREKA_ELBV2_PORT`

These can be set to explicitly specify the load balancer hostname and port at runtime to provide an alternative to a dynamic lookup, which is slow (because it has to sleep for a little while while the container joins the target group).

The PR also renames the older flag to  `SERVICE_EUREKA_LOOKUP_ELBV2_ENDPOINT` from `USE`.  This just makes it more obvious that the flag will be used for automatic lookup.  If you specify the older flag _and_ the explicit variables, then the explicits will be used in preference.