### PR TITLE
Merge upstream registrator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM gliderlabs/alpine:3.3
+FROM alpine:3.5
 ENTRYPOINT ["/bin/registrator"]
 
 COPY . /go/src/github.com/gliderlabs/registrator
-RUN apk-install -t build-deps build-base go git mercurial \
+RUN apk --no-cache add -t build-deps build-base go git \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \
+  && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
 	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
 	&& rm -rf /go \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,10 @@
-FROM gliderlabs/alpine:3.3
+FROM alpine:3.5
 CMD ["/bin/registrator"]
 
 ENV GOPATH /go
-RUN apk-install build-base go git mercurial
+RUN apk --no-cache add build-base go git
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN cd /go/src/github.com/gliderlabs/registrator \
+  && git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
 	&& go build -ldflags "-X main.Version=dev" -o /bin/registrator

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,15 @@ release:
 	cp build/* release
 	gh-release create gliderlabs/$(NAME) $(VERSION) \
 		$(shell git rev-parse --abbrev-ref HEAD) $(VERSION)
-	glu hubtag gliderlabs/$(NAME) $(VERSION)
 
 docs:
 	boot2docker ssh "sync; sudo sh -c 'echo 3 > /proc/sys/vm/drop_caches'" || true
 	docker run --rm -it -p 8000:8000 -v $(PWD):/work gliderlabs/pagebuilder mkdocs serve
 
 circleci:
-	rm -f ~/.gitconfig
-	go get -u github.com/gliderlabs/glu
-	glu circleci
+	rm ~/.gitconfig
+ifneq ($(CIRCLE_BRANCH), release)
+	echo build-$$CIRCLE_BUILD_NUM > VERSION
+endif
 
 .PHONY: build release docs

--- a/bridge/types_test.go
+++ b/bridge/types_test.go
@@ -23,3 +23,6 @@ func (f *fakeAdapter) Deregister(service *Service) error {
 func (f *fakeAdapter) Refresh(service *Service) error {
 	return nil
 }
+func (f *fakeAdapter) Services() ([]*Service, error) {
+	return nil, nil
+}

--- a/bridge/util_test.go
+++ b/bridge/util_test.go
@@ -1,0 +1,59 @@
+package bridge
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapedComma(t *testing.T) {
+	cases := []struct {
+		Tag      string
+		Expected []string
+	}{
+		{
+			Tag:      "",
+			Expected: []string{},
+		},
+		{
+			Tag:      "foobar",
+			Expected: []string{"foobar"},
+		},
+		{
+			Tag:      "foo,bar",
+			Expected: []string{"foo", "bar"},
+		},
+		{
+			Tag:      "foo\\,bar",
+			Expected: []string{"foo,bar"},
+		},
+		{
+			Tag:      "foo,bar\\,baz",
+			Expected: []string{"foo", "bar,baz"},
+		},
+		{
+			Tag:      "\\,foobar\\,",
+			Expected: []string{",foobar,"},
+		},
+		{
+			Tag:      ",,,,foo,,,bar,,,",
+			Expected: []string{"foo", "bar"},
+		},
+		{
+			Tag:      ",,,,",
+			Expected: []string{},
+		},
+		{
+			Tag:      ",,\\,,",
+			Expected: []string{","},
+		},
+	}
+
+	for _, c := range cases {
+		results := recParseEscapedComma(c.Tag)
+		sort.Strings(c.Expected)
+		sort.Strings(results)
+		assert.EqualValues(t, c.Expected, results)
+	}
+}

--- a/docs/user/services.md
+++ b/docs/user/services.md
@@ -166,6 +166,13 @@ Results in `Service`:
 
 Keep in mind not all of the `Service` object may be used by the registry backend. For example, currently none of them support registering arbitrary attributes. This field is there for future use.
 
+The comma can be escaped by adding a backslash, such as the following example:
+
+    $ docker run -d --name redis.0 -p 10000:6379 \
+        -e "SERVICE_NAME=db" \
+        -e "SERVICE_TAGS=/(;\\,:-_)/" \
+        -e "SERVICE_REGION=us2" progrium/redis
+
 ### Multiple services with defaults
 
 	$ docker run -d --name nginx.0 -p 4443:443 -p 8000:80 progrium/nginx


### PR DESCRIPTION
This is a merge from gliderlabs/registrator master branch to keep us up to date with upstream.

* feat(service_tags): Support escaped comma
* test(bridge): Adds test for escaped comma in tags + fix types_test.go tests