### PR TITLE
Add startup option require-label to only register particular containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
-DEV_RUN_OPTS ?= -ttl 60 --ttl-refresh 30 eureka://localhost:8090/eureka/v2
+DEV_RUN_OPTS ?= -ttl 60 -ttl-refresh 30 -require-label REGISTER -ip 127.0.0.1  eureka://localhost:8090/eureka/v2
 RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator
 
 dev:
 	docker kill reg_eureka; echo Stopped.
-	docker run --rm --name reg_eureka -td -p 8090:8080 netflixoss/eureka:1.1.147
+	docker run --rm --name reg_eureka -e "SERVICE_REGISTER=true" -td -p 8090:8080 netflixoss/eureka:1.1.147
 	docker build -f Dockerfile.dev -t $(NAME):dev .
 	docker run --rm \
 		--net=host \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
-DEV_RUN_OPTS ?= -ttl 60 -ttl-refresh 30 -require-label REGISTER -ip 127.0.0.1  eureka://localhost:8090/eureka/v2
+DEV_RUN_OPTS ?= -ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1  eureka://localhost:8090/eureka/v2
 RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator
 
 dev:

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -304,6 +304,14 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		return nil
 	}
 
+	if b.config.RequireLabel != "" {
+		log.Printf("Checking for label SERVICE_%v", b.config.RequireLabel)
+		if mapDefault(metadata, strings.ToLower(b.config.RequireLabel), "") == "" {
+			log.Printf("Did not find label SERVICE_%v", b.config.RequireLabel)
+			return nil
+		}
+	}
+
 	service := new(Service)
 	service.Origin = port
 	service.ID = hostname + ":" + container.Name[1:] + ":" + port.ExposedPort

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -304,10 +304,10 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 		return nil
 	}
 
-	if b.config.RequireLabel != "" {
-		log.Printf("Checking for label SERVICE_%v", b.config.RequireLabel)
-		if mapDefault(metadata, strings.ToLower(b.config.RequireLabel), "") == "" {
-			log.Printf("Did not find label SERVICE_%v", b.config.RequireLabel)
+	if b.config.RequireLabel {
+		log.Printf("Checking for label SERVICE_REGISTER")
+		if mapDefault(metadata, "register", "") == "" {
+			log.Printf("Did not find label SERVICE_REGISTER")
 			return nil
 		}
 	}

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -28,6 +28,7 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
+	RequireLabel    string
 }
 
 type Service struct {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -28,7 +28,7 @@ type Config struct {
 	RefreshInterval int
 	DeregisterCheck string
 	Cleanup         bool
-	RequireLabel    string
+	RequireLabel    bool
 }
 
 type Service struct {

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -44,6 +44,7 @@ Option                           | Since | Description
 `-ttl <seconds>`                 |       | TTL for services. Default: 0, no expiry (supported backends only)
 `-ttl-refresh <seconds>`         |       | Frequency service TTLs are refreshed (supported backends only)
 `-useIpFromLabel <label>`        |       | Uses the IP address stored in the given label, which is assigned to a container, for registration with Consul
+`-require-label <label>`         |       | Only register containers which have this particular label, and ignore all others.
 
 If the `-internal` option is used, Registrator will register the docker0
 internal IP and port instead of the host mapped ones.

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -44,7 +44,7 @@ Option                           | Since | Description
 `-ttl <seconds>`                 |       | TTL for services. Default: 0, no expiry (supported backends only)
 `-ttl-refresh <seconds>`         |       | Frequency service TTLs are refreshed (supported backends only)
 `-useIpFromLabel <label>`        |       | Uses the IP address stored in the given label, which is assigned to a container, for registration with Consul
-`-require-label <label>`         |       | Only register containers which have this particular label, and ignore all others.
+`-require-label`                 |       | Only register containers which have a SERVICE_REGISTER label, and ignore all others.
 
 If the `-internal` option is used, Registrator will register the docker0
 internal IP and port instead of the host mapped ones.

--- a/registrator.go
+++ b/registrator.go
@@ -29,6 +29,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
+var requireLabel = flag.String("require-label", "", "Only register containers which have a particular label, and ignore all others.")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -74,6 +75,10 @@ func main() {
 		log.Println("Forcing host IP to", *hostIp)
 	}
 
+	if *requireLabel != "" {
+		log.Printf("Required label to register containers will be SERVICE_%v", *requireLabel)
+	}
+
 	if (*refreshTtl == 0 && *refreshInterval > 0) || (*refreshTtl > 0 && *refreshInterval == 0) {
 		assert(errors.New("-ttl and -ttl-refresh must be specified together or not at all"))
 	} else if *refreshTtl > 0 && *refreshTtl <= *refreshInterval {
@@ -105,6 +110,7 @@ func main() {
 		RefreshInterval: *refreshInterval,
 		DeregisterCheck: *deregister,
 		Cleanup:         *cleanup,
+		RequireLabel:    *requireLabel,
 	})
 
 	assert(err)

--- a/registrator.go
+++ b/registrator.go
@@ -29,7 +29,7 @@ var deregister = flag.String("deregister", "always", "Deregister exited services
 var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establish a connection with the backend. Use -1 for infinite retries")
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
-var requireLabel = flag.String("require-label", "", "Only register containers which have a particular label, and ignore all others.")
+var requireLabel = flag.Bool("require-label", false, "Only register containers which have the SERVICE_REGISTER label, and ignore all others.")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -75,8 +75,8 @@ func main() {
 		log.Println("Forcing host IP to", *hostIp)
 	}
 
-	if *requireLabel != "" {
-		log.Printf("Required label to register containers will be SERVICE_%v", *requireLabel)
+	if *requireLabel {
+		log.Printf("SERVICE_REGISTER label is required to register containers.")
 	}
 
 	if (*refreshTtl == 0 && *refreshInterval > 0) || (*refreshTtl > 0 && *refreshInterval == 0) {


### PR DESCRIPTION
Fixes issue https://github.com/hudl/registrator/issues/15

- Add a new command line option to registrator: `-require-label`
- Change Makefile to make testing easier.  `make dev` still registers local eureka container that it starts for convenience when testing.
- Update documentation accordingly

Example:

If you specify `-require-label` when starting registrator,  it will check for a label called SERVICE_REGISTER on every new container.  If this is not present, the container will not be registered.  

*Note:* This can be set to ANY string, e.g true, yes, 1, would all work. Setting the label to a "falsey" value will NOT do the opposite.  

If you instead wish to include all containers and blacklist a few, you should leave off this flag, and set the SERVICE_IGNORE label on those containers you wish to ignore.