### PR TITLE
Make HostName a HostName again.

### DIFF
--- a/aws/elb.go
+++ b/aws/elb.go
@@ -237,7 +237,9 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance, useCache
 	if service.Attrs["eureka_elbv2_hostname"] != "" && service.Attrs["eureka_elbv2_port"] != "" {
 		log.Printf("Found ELBv2 hostname=%v and port=%v options, using these.", service.Attrs["eureka_elbv2_hostname"], service.Attrs["eureka_elbv2_port"])
 		registration.Port, _ = strconv.Atoi(service.Attrs["eureka_elbv2_port"])
-		registration.IPAddr = service.Attrs["eureka_elbv2_hostname"]
+		registration.HostName = service.Attrs["eureka_elbv2_hostname"]
+		registration.IPAddr = ""
+		registration.VipAddress = ""
 		elbEndpoint = service.Attrs["eureka_elbv2_hostname"] + "_" + service.Attrs["eureka_elbv2_port"]
 
 	} else {
@@ -252,7 +254,8 @@ func setRegInfo(service *bridge.Service, registration *eureka.Instance, useCache
 		elbStrPort := strconv.FormatInt(elbMetadata.Port, 10)
 		elbEndpoint = elbMetadata.DNSName + "_" + elbStrPort
 		registration.Port = int(elbMetadata.Port)
-		registration.IPAddr = elbMetadata.DNSName
+		registration.IPAddr = ""
+		registration.HostName = elbMetadata.DNSName
 	}
 
 	registration.SetMetadataString("has-elbv2", "true")


### PR DESCRIPTION
This PR reworks things so that HostName is not used as an identifier in most circumstances.

1. AWS instanceID is updated to <IP>_<Port> when using the AWS datacentre type (default).  This is the case whether running locally or on AWS.
2. When running on AWS, you need to set the `eureka_datacenterinfo_auto_populate` flag to get the actual data centre information.
3. Eureka `HostName` will get set to the AWS _private_ hostname, if that is available.  
4. Eureka `HostName` will only fallback to an IP address, if auto populate is turned off, and no name is provided with the `eureka_datacenterinfo_localhostname` option.
5. If you set `eureka_lookup_elbv2_endpoint` or manually set `eureka_elbv2_hostname` and `eureka_elbv2_port` then these will be registered as appropriate.  However, when using an ALB, `ipAddr` and `vipAddress` will now be removed, seeing as they are not useful and are misleading.




