### PR TITLE
Allow ELBv2s to register independently of containers.

### DIFF
--- a/aws/elb.go
+++ b/aws/elb.go
@@ -284,6 +284,9 @@ func setRegInfo(service *bridge.Service, registration *fargo.Instance, useCache 
 			PublicHostname: registration.HostName,
 			HostName:       registration.HostName,
 		}
+		registration.SetMetadataString("container-id", "")
+		registration.SetMetadataString("container-name", "")
+		registration.SetMetadataString("aws-instance-id", "")
 	}
 
 	registration.SetMetadataString("has-elbv2", "true")

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -299,7 +299,7 @@ func RegisterWithELBv2(service *bridge.Service, registration *fargo.Instance, cl
 		log.Printf("Found ELBv2 flags, will attempt to register LB for: %s\n", GetUniqueID(*registration))
 		elbReg := setRegInfo(service, registration, false)
 		if elbReg != nil {
-			err := client.RegisterInstance(elbReg)
+			err := client.ReregisterInstance(elbReg)
 			if err == nil {
 				registrations[service.Origin.ContainerID] = true
 			}
@@ -313,7 +313,7 @@ func RegisterWithELBv2(service *bridge.Service, registration *fargo.Instance, cl
 func HeartbeatELBv2(service *bridge.Service, registration *fargo.Instance, client fargo.EurekaConnection) error {
 	if CheckELBFlags(service) {
 		log.Printf("Heartbeating ELBv2: %s\n", GetUniqueID(*registration))
-		elbReg := setRegInfo(service, registration, false)
+		elbReg := setRegInfo(service, registration, true)
 		if elbReg != nil {
 			err := client.HeartBeatInstance(elbReg)
 			return err

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -178,9 +178,13 @@ func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	if aws.CheckELBFlags(service) {
 		aws.RemoveLBCache(service.Origin.ContainerID)
 	}
-	log.Println("Deregistering", GetUniqueID(*registration))
-	instance := r.client.DeregisterInstance(registration)
-	return instance
+	// Don't deregister ALB registrations.  Just leave them to expire if there are no heartbeats
+	if !aws.CheckELBOnlyReg(service) {
+		log.Println("Deregistering", GetUniqueID(*registration))
+		err := r.client.DeregisterInstance(registration)
+		return err
+	}
+	return nil
 }
 
 func (r *EurekaAdapter) Refresh(service *bridge.Service) error {

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -46,7 +46,7 @@ func (r *EurekaAdapter) Ping() error {
 }
 
 // Note: This is a function that is passed to the fargo library to determine how each registration is identified in eureka
-func uniqueID(instance fargo.Instance) string {
+func GetUniqueID(instance fargo.Instance) string {
 	return instance.HostName + "_" + strconv.Itoa(instance.Port)
 }
 
@@ -68,7 +68,7 @@ func instanceInformation(service *bridge.Service) *fargo.Instance {
 	registration := new(fargo.Instance)
 	var awsMetadata *aws.Metadata
 
-	registration.UniqueID = uniqueID
+	registration.UniqueID = GetUniqueID
 	registration.App = service.Name
 	registration.Port = service.Port
 
@@ -126,7 +126,7 @@ func instanceInformation(service *bridge.Service) *fargo.Instance {
 			AvailabilityZone: awsMetadata.AvailabilityZone,
 			PublicHostname:   awsMetadata.PublicHostname,
 			PublicIpv4:       awsMetadata.PublicIP,
-			InstanceID:       uniqueID(*registration), // This is deliberate - due to limitations in uniqueIDs
+			InstanceID:       GetUniqueID(*registration), // This is deliberate - due to limitations in uniqueIDs
 			LocalHostname:    awsMetadata.PrivateHostname,
 			HostName:         awsMetadata.PrivateHostname,
 			LocalIpv4:        awsMetadata.PrivateIP,
@@ -136,7 +136,7 @@ func instanceInformation(service *bridge.Service) *fargo.Instance {
 		registration.DataCenterInfo.Name = fargo.Amazon
 		registration.HostName = ShortHandTernary(service.Attrs["eureka_datacenterinfo_localhostname"], service.IP)
 		registration.DataCenterInfo.Metadata = fargo.AmazonMetadataType{
-			InstanceID:     uniqueID(*registration), // This is deliberate - due to limitations in uniqueIDs
+			InstanceID:     GetUniqueID(*registration), // This is deliberate - due to limitations in uniqueIDs
 			PublicHostname: ShortHandTernary(service.Attrs["eureka_datacenterinfo_publichostname"], service.Origin.HostIP),
 			PublicIpv4:     ShortHandTernary(service.Attrs["eureka_datacenterinfo_publicipv4"], service.Origin.HostIP),
 			LocalHostname:  ShortHandTernary(service.Attrs["eureka_datacenterinfo_localhostname"], service.IP),
@@ -147,7 +147,7 @@ func instanceInformation(service *bridge.Service) *fargo.Instance {
 		registration.DataCenterInfo.Name = fargo.MyOwn
 		// We don't have a uniqueID, so manipulate hostname to provide it there.
 		registration.HostName = service.IP
-		registration.HostName = uniqueID(*registration)
+		registration.HostName = GetUniqueID(*registration)
 	}
 
 	// If flag is set, register the AWS public IP as the endpoint instead of the private one
@@ -178,16 +178,21 @@ func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	if aws.CheckELBFlags(service) {
 		aws.RemoveLBCache(service.Origin.ContainerID)
 	}
-	log.Println("Deregistering", uniqueID(*registration))
+	log.Println("Deregistering", GetUniqueID(*registration))
 	instance := r.client.DeregisterInstance(registration)
 	return instance
 }
 
 func (r *EurekaAdapter) Refresh(service *bridge.Service) error {
 	registration := instanceInformation(service)
-	err := r.client.HeartBeatInstance(registration)
-	log.Println("Done heartbeating for:", uniqueID(*registration))
-	return err
+	if aws.CheckELBFlags(service) {
+		aws.HeartbeatELBv2(service, registration, r.client)
+		return nil
+	} else {
+		err := r.client.HeartBeatInstance(registration)
+		log.Println("Done heartbeating for:", GetUniqueID(*registration))
+		return err
+	}
 }
 
 func (r *EurekaAdapter) Services() ([]*bridge.Service, error) {


### PR DESCRIPTION
This PR makes some changes to the way ELBv2 registrations work:

- New option `EUREKA_ELBv2_ONLY_REGISTRATION` - defaults to _true_.  This works in line with the other ELBv2 options, which also must be set appropriately.
- If you override, and set it to _false_, then the previous behaviour of adding the ELB hostname and port to each individual container registration will happen.
- Each ELBv2 endpoint (DNS name and port combination) will be registered in eureka, but containers will not.
- Each time a new container associated with the ELB endpoint is started, registrator will send a `Reregister` to eureka, updating the metadata.
- During deploys, the metadata will be updated once for each new container to start.  As such, the newest metadata always wins.
- Heartbeats are still piggybacked onto container lifecycles.  As such, heartbeats will be sent to a given ELB endpoint as many times as there are associated containers running.  It would be possible to alter `--ttl` and `-ttl-refresh` registrator startup options to compensate and reduce the number of heartbeats if desired.
- A ELBv2 will not be explicitly removed once registered with eureka.  Heartbeats will simply stop, as and when associated containers die.  Once all associated containers stop heartbeating (that would be all within an ECS target group), the record would expire based on the `--ttl` registrator startup value.

