### PR TITLE
Add check for healthy containers before registering a new ELB as up.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ ENV GOPATH /go
 COPY ./run-registrator.sh /bin
 RUN chmod 755 /bin/run-registrator.sh
 COPY . /go/src/github.com/gliderlabs/registrator
-RUN apk --no-cache add -t build-deps build-base go coreutils git bash \
-	&& apk --no-cache add ca-certificates \
+RUN apk --no-cache add -t build-deps build-base go git \
+	&& apk --no-cache add ca-certificates bash coreutils \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \
   && git config --global http.https://gopkg.in.followRedirects true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM alpine:3.5
-ENTRYPOINT ["/bin/registrator"]
+ENTRYPOINT ["/bin/registrator", "2>&1", "|", "tee", "-a", "/logs/registrator-$HOSTNAME.log"]
 
+CMD mkdir /logs
 COPY . /go/src/github.com/gliderlabs/registrator
-RUN apk --no-cache add -t build-deps build-base go git \
+RUN apk --no-cache add -t build-deps build-base go coreutils git \
 	&& apk --no-cache add ca-certificates \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.5
-ENTRYPOINT ["/bin/registrator", "2>&1", "|", "tee", "-a", "/logs/registrator-$HOSTNAME.log"]
+ENTRYPOINT ["/bin/registrator"]
 
 CMD mkdir /logs
 COPY . /go/src/github.com/gliderlabs/registrator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM alpine:3.5
 ENTRYPOINT ["/bin/run-registrator.sh"]
 
-CMD mkdir /logs
-COPY . /go/src/github.com/gliderlabs/registrator
+RUN mkdir /logs
+ENV GOPATH /go
 COPY ./run-registrator.sh /bin
-CMD chmod 755 /bin/run-registrator.sh
+RUN chmod 755 /bin/run-registrator.sh
+COPY . /go/src/github.com/gliderlabs/registrator
 RUN apk --no-cache add -t build-deps build-base go coreutils git bash \
 	&& apk --no-cache add ca-certificates \
 	&& cd /go/src/github.com/gliderlabs/registrator \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:3.5
-ENTRYPOINT ["/bin/registrator"]
+ENTRYPOINT ["/bin/run-registrator.sh"]
 
 CMD mkdir /logs
 COPY . /go/src/github.com/gliderlabs/registrator
-RUN apk --no-cache add -t build-deps build-base go coreutils git \
+COPY ./run-registrator.sh /bin
+CMD chmod 755 /bin/run-registrator.sh
+RUN apk --no-cache add -t build-deps build-base go coreutils git bash \
 	&& apk --no-cache add ca-certificates \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,9 @@
 FROM alpine:3.5
-CMD ["/bin/registrator"]
+ENTRYPOINT ["/bin/registrator"]
 
+CMD mkdir /logs
 ENV GOPATH /go
-RUN apk --no-cache add build-base go git ca-certificates
+RUN apk --no-cache add build-base go coreutils git ca-certificates
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN cd /go/src/github.com/gliderlabs/registrator \
   && git config --global http.https://gopkg.in.followRedirects true \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,9 +1,11 @@
 FROM alpine:3.5
-ENTRYPOINT ["/bin/registrator"]
+ENTRYPOINT ["/bin/run-registrator.sh"]
 
 CMD mkdir /logs
 ENV GOPATH /go
-RUN apk --no-cache add build-base go coreutils git ca-certificates
+COPY ./run-registrator.sh /bin
+CMD chmod 755 /bin/run-registrator.sh
+RUN apk --no-cache add build-base go coreutils git ca-certificates bash
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN cd /go/src/github.com/gliderlabs/registrator \
   && git config --global http.https://gopkg.in.followRedirects true \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,10 +1,10 @@
 FROM alpine:3.5
 ENTRYPOINT ["/bin/run-registrator.sh"]
 
-CMD mkdir /logs
+RUN mkdir /logs
 ENV GOPATH /go
 COPY ./run-registrator.sh /bin
-CMD chmod 755 /bin/run-registrator.sh
+RUN chmod 755 /bin/run-registrator.sh
 RUN apk --no-cache add build-base go coreutils git ca-certificates bash
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN cd /go/src/github.com/gliderlabs/registrator \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DEV_RUN_OPTS ?= -ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1  eureka://localhost:8090/eureka/v2
+DEV_RUN_OPTS ?=-ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1  eureka://localhost:8090/eureka/v2
 PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
 
@@ -9,10 +9,10 @@ dev:
 	docker kill reg_eureka; echo Stopped.
 	docker run --rm --name reg_eureka -e "SERVICE_REGISTER=true" -td -p 8090:8080 netflixoss/eureka:1.1.147
 	docker build -f Dockerfile.dev -t $(NAME):dev .
-	docker run --rm \
+	docker run -ti --rm \
 		--net=host \
 		-v /var/run/docker.sock:/tmp/docker.sock \
-		$(NAME):dev /bin/registrator $(DEV_RUN_OPTS)
+		$(NAME):dev $(DEV_RUN_OPTS)
 	docker kill reg_eureka
 
 build:

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -218,6 +218,7 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 	// Assumption: that that there is only one LB for the target group (though the data structure allows more)
 	for _, tgs := range tgslice {
 		for _, tg := range tgs.TargetGroups {
+			log.Printf("Checking target group: %v", *tg.TargetGroupArn)
 
 			thParams := &elbv2.DescribeTargetHealthInput{
 				TargetGroupArn: awssdk.String(*tg.TargetGroupArn),
@@ -235,6 +236,7 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 			}
 			for _, thd := range tarH.TargetHealthDescriptions {
 				if *thd.Target.Port == port && *thd.Target.Id == instanceID {
+					log.Printf("Target matched!")
 					lbArns = tg.LoadBalancerArns
 					tgArn = *tg.TargetGroupArn
 					break

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -420,6 +420,7 @@ func RegisterWithELBv2(service *bridge.Service, registration *fargo.Instance, cl
 			time.Sleep(period)
 			elbReg = setRegInfo(service, registration)
 			if elbReg != nil {
+				previousStatus = elbReg.Status
 				err := client.ReregisterInstance(elbReg)
 				return err
 			}

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -390,9 +390,10 @@ func setRegInfo(service *bridge.Service, registration *fargo.Instance) *fargo.In
 
 	// Test for at least one healthy container in the target group.  We want to mark the ALB as down if there isn't one yet
 	if previousStatus == fargo.UNKNOWN || previousStatus == fargo.STARTING {
-		thList, err := GetHealthyTargets(elbMetadata.TargetGroupArn)
-		if err != nil {
-			log.Printf("Unable to find list of healthy targets for: %s, Error: %s\n", registration.HostName, err)
+		log.Printf("Looking up healthy targets for TG: %v", elbMetadata.TargetGroupArn)
+		thList, err2 := GetHealthyTargets(elbMetadata.TargetGroupArn)
+		if err2 != nil {
+			log.Printf("Unable to find list of healthy targets for: %s, Error: %s\n", registration.HostName, err2)
 			return nil
 		}
 		if len(thList) == 0 {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -369,12 +369,11 @@ func setRegInfo(service *bridge.Service, registration *fargo.Instance) *fargo.In
 		// We don't have the ELB endpoint, so look it up.
 
 		elbMetadata1, err := GetELBV2ForContainer(service.Origin.ContainerID, awsMetadata.InstanceID, int64(registration.Port))
-		elbMetadata = *elbMetadata1
-		log.Printf("elb data: %+v", elbMetadata.TargetGroupArn)
 		if err != nil {
 			log.Printf("Unable to find associated ELBv2 for: %s, Error: %s\n", registration.HostName, err)
 			return nil
 		}
+		elbMetadata = *elbMetadata1
 
 		elbStrPort := strconv.FormatInt(elbMetadata.Port, 10)
 		elbEndpoint = elbMetadata.DNSName + "_" + elbStrPort

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -424,6 +424,7 @@ func testStatus(containerID string, eurekaStatus fargo.StatusType, previousStatu
 	}
 
 	if previousStatus != fargo.UP {
+		log.Printf("Previous status was: %v, need to check for healthy targets.", previousStatus)
 		// The ELB data should be cached, so just get it from there.
 		result, found := generalCache.Get(containerID)
 		if !found {
@@ -452,6 +453,7 @@ func testStatus(containerID string, eurekaStatus fargo.StatusType, previousStatu
 // Test eureka registration status and mutate registration accordingly depending on container health.
 func testHealth(service *bridge.Service, client fargo.EurekaConnection, elbReg *fargo.Instance) {
 	eurekaStatus := getELBStatus(client, elbReg)
+	log.Printf("Eureka status check gave: %v", eurekaStatus)
 	containerID := service.Origin.ContainerID
 	last := previousStatus
 	previousStatus, elbReg.Status = testStatus(containerID, eurekaStatus, last)

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -230,6 +230,7 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 			}
 			tarH, _ := out2.(*elbv2.DescribeTargetHealthOutput)
 			if tarH.TargetHealthDescriptions == nil {
+				log.Printf("Target health descriptions were nil for: %v", *tg.TargetGroupArn)
 				break
 			}
 			for _, thd := range tarH.TargetHealthDescriptions {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -229,6 +229,10 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 				return nil, err
 			}
 			tarH, _ := out2.(*elbv2.DescribeTargetHealthOutput)
+			if tarH.TargetHealthDescriptions == nil {
+				log.Printf("TargetHealthDescriptions are nil.  Are healthchecks disabled?")
+				return nil, nil
+			}
 			for _, thd := range tarH.TargetHealthDescriptions {
 				if *thd.Target.Port == port && *thd.Target.Id == instanceID {
 					lbArns = tg.LoadBalancerArns

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -32,7 +32,7 @@ type lookupValues struct {
 const DEFAULT_EXP_TIME = 10 * time.Second
 
 var generalCache = gocache.New(DEFAULT_EXP_TIME, DEFAULT_EXP_TIME)
-var previousStatus fargo.StatusType
+var previousStatus = fargo.UNKNOWN
 var refreshInterval int
 
 type any interface{}
@@ -450,10 +450,12 @@ func testStatus(containerID string, eurekaStatus fargo.StatusType, previousStatu
 }
 
 // Test eureka registration status and mutate registration accordingly depending on container health.
-func testHealth(service *bridge.Service, client fargo.EurekaConnection, registration *fargo.Instance) {
-	eurekaStatus := getELBStatus(client, registration)
+func testHealth(service *bridge.Service, client fargo.EurekaConnection, elbReg *fargo.Instance) {
+	eurekaStatus := getELBStatus(client, elbReg)
 	containerID := service.Origin.ContainerID
-	previousStatus, registration.Status = testStatus(containerID, eurekaStatus, previousStatus)
+	last := previousStatus
+	previousStatus, elbReg.Status = testStatus(containerID, eurekaStatus, last)
+	log.Printf("Status health check returned prev: %v registration: %v", previousStatus, elbReg.Status)
 }
 
 // RegisterWithELBv2 - If called, and flags are active, register an ELBv2 endpoint instead of the container directly

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -101,6 +101,7 @@ func getAllTargetGroups(svc *elbv2.ELBV2) ([]*elbv2.DescribeTargetGroupsOutput, 
 			return nil, e
 		}
 	}
+	log.Printf("%v target groups retrieved.", len(tgs))
 	return tgs, e
 }
 
@@ -217,6 +218,7 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 	// Check each target group's target list for a matching port and instanceID
 	// Assumption: that that there is only one LB for the target group (though the data structure allows more)
 	for _, tgs := range tgslice {
+		log.Printf("%v target groups to check.", len(tgs.TargetGroups))
 		for _, tg := range tgs.TargetGroups {
 			log.Printf("Checking target group: %v", *tg.TargetGroupArn)
 

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -151,7 +151,7 @@ func GetHealthyTargets(tgArn string) (thds []*elbv2.TargetHealthDescription, err
 	if refreshInterval != 0 {
 		healthCheckCacheTime = (time.Duration(refreshInterval) * time.Second) - (1 * time.Second)
 	} else {
-		healthCheckCacheTime = time.Second * 14
+		healthCheckCacheTime = DEFAULT_EXP_TIME
 	}
 	out2, err := getAndCache(*thParams.TargetGroupArn, thParams, svc.DescribeTargetHealth, healthCheckCacheTime)
 	if err != nil || out2 == nil {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -101,7 +101,6 @@ func getAllTargetGroups(svc *elbv2.ELBV2) ([]*elbv2.DescribeTargetGroupsOutput, 
 			return nil, e
 		}
 	}
-	log.Printf("%v target groups retrieved.", len(tgs))
 	return tgs, e
 }
 
@@ -220,7 +219,6 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 	for _, tgs := range tgslice {
 		log.Printf("%v target groups to check.", len(tgs.TargetGroups))
 		for _, tg := range tgs.TargetGroups {
-			log.Printf("Checking target group: %v", *tg.TargetGroupArn)
 
 			thParams := &elbv2.DescribeTargetHealthInput{
 				TargetGroupArn: awssdk.String(*tg.TargetGroupArn),
@@ -234,11 +232,11 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 			tarH, _ := out2.(*elbv2.DescribeTargetHealthOutput)
 			if tarH.TargetHealthDescriptions == nil {
 				log.Printf("Target health descriptions were nil for: %v", *tg.TargetGroupArn)
-				break
+				continue
 			}
 			for _, thd := range tarH.TargetHealthDescriptions {
 				if *thd.Target.Port == port && *thd.Target.Id == instanceID {
-					log.Printf("Target matched!")
+					log.Printf("Target group matched - %v", *tg.TargetGroupArn)
 					lbArns = tg.LoadBalancerArns
 					tgArn = *tg.TargetGroupArn
 					break

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -151,7 +151,7 @@ func GetHealthyTargets(tgArn string) (thds []*elbv2.TargetHealthDescription, err
 	if refreshInterval != 0 {
 		healthCheckCacheTime = (time.Duration(refreshInterval) * time.Second) - (1 * time.Second)
 	} else {
-		healthCheckCacheTime = time.Second * 29
+		healthCheckCacheTime = time.Second * 14
 	}
 	out2, err := getAndCache(*thParams.TargetGroupArn, thParams, svc.DescribeTargetHealth, healthCheckCacheTime)
 	if err != nil || out2 == nil {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -416,15 +416,15 @@ func getELBStatus(client fargo.EurekaConnection, registration *fargo.Instance) f
 }
 
 // Return appropriate registration statuses based on input and cached ELB data
-func testStatus(containerID string, eurekaStatus fargo.StatusType, previousStatus fargo.StatusType) (newStatus fargo.StatusType, regStatus fargo.StatusType) {
+func testStatus(containerID string, eurekaStatus fargo.StatusType, inputStatus fargo.StatusType) (newStatus fargo.StatusType, regStatus fargo.StatusType) {
 
 	// Nothing to do if eureka says we're up, just return UP
 	if eurekaStatus == fargo.UP {
 		return fargo.UP, fargo.UP
 	}
 
-	if previousStatus != fargo.UP {
-		log.Printf("Previous status was: %v, need to check for healthy targets.", previousStatus)
+	if inputStatus != fargo.UP {
+		log.Printf("Previous status was: %v, need to check for healthy targets.", inputStatus)
 		// The ELB data should be cached, so just get it from there.
 		result, found := generalCache.Get(containerID)
 		if !found {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -230,8 +230,7 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 			}
 			tarH, _ := out2.(*elbv2.DescribeTargetHealthOutput)
 			if tarH.TargetHealthDescriptions == nil {
-				log.Printf("TargetHealthDescriptions are nil.  Are healthchecks disabled?")
-				return nil, nil
+				break
 			}
 			for _, thd := range tarH.TargetHealthDescriptions {
 				if *thd.Target.Port == port && *thd.Target.Id == instanceID {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -229,8 +229,8 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 				log.Printf("An error occurred using DescribeTargetHealth: %s \n", err.Error())
 				return nil, err
 			}
-			tarH, _ := out2.(*elbv2.DescribeTargetHealthOutput)
-			if tarH.TargetHealthDescriptions == nil {
+			tarH, ok := out2.(*elbv2.DescribeTargetHealthOutput)
+			if !ok || tarH.TargetHealthDescriptions == nil {
 				continue
 			}
 			for _, thd := range tarH.TargetHealthDescriptions {

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -373,7 +373,7 @@ func setRegInfo(service *bridge.Service, registration *fargo.Instance) *fargo.In
 		// We don't have the ELB endpoint, so look it up.
 
 		elbMetadata1, err := GetELBV2ForContainer(service.Origin.ContainerID, awsMetadata.InstanceID, int64(registration.Port))
-		if err != nil {
+		if err != nil || elbMetadata1 != nil {
 			log.Printf("Unable to find associated ELBv2 for: %s, Error: %s\n", registration.HostName, err)
 			return nil
 		}

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -632,7 +632,7 @@ func Test_testHealth(t *testing.T) {
 	t.Run("Should return UP because of healthy targets 1", func(t *testing.T) {
 		flushCache(tgArn)
 		setupTHDCache(tgArn, healthyTHDs)
-		var previousStatus eureka.StatusType
+		previousStatus := eureka.UNKNOWN
 		eurekaStatus := eureka.UNKNOWN
 		wanted := eureka.UP
 		wantedNow := eureka.UP

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -387,6 +387,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 }
 
 func (b *Bridge) remove(containerId string, deregister bool) {
+	log.Printf("container stop detected for: %v", containerId)
 	b.Lock()
 	defer b.Unlock()
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -305,9 +305,8 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	}
 
 	if b.config.RequireLabel {
-		log.Printf("Checking for label SERVICE_REGISTER")
 		if strings.ToLower(mapDefault(metadata, "register", "false")) == "false" {
-			log.Printf("Did not find label SERVICE_REGISTER")
+			log.Printf("Did not find label SERVICE_REGISTER on %s - ignoring.", container.Name)
 			return nil
 		}
 	}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -306,7 +306,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 
 	if b.config.RequireLabel {
 		log.Printf("Checking for label SERVICE_REGISTER")
-		if mapDefault(metadata, "register", "") == "" {
+		if strings.ToLower(mapDefault(metadata, "register", "false")) == "false" {
 			log.Printf("Did not find label SERVICE_REGISTER")
 			return nil
 		}

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -206,6 +206,7 @@ SERVICE_EUREKA_REGISTER_AWS_PUBLIC_IP = false (if true, set VIP and IPADDR value
 SERVICE_EUREKA_LOOKUP_ELBV2_ENDPOINT = false (if true, an entry will be added for an ELBv2 connected to a container target group in ECS - see below for more details)
 SERVICE_EUREKA_ELBV2_HOSTNAME = If set, will explicitly be used as the ELBv2 hostname - see below section.
 SERVICE_EUREKA_ELBV2_PORT = If set, will be explicitly used as the ELBv2 Port - see below.
+SERVICE_EUREKA_ELBV2_TARGETGROUP = If set, will be explicitly used as the ELBv2 TargetGroup - see below.
 SERVICE_EUREKA_ELBV2_ONLY_REGISTRATION = true (if false then adding the ELB hostname and port to each individual container registration will happen).
 ```
 
@@ -233,9 +234,9 @@ It will attempt to connect to the AWS service using the IAM role of the containe
 
 #### Manual Endpoint Specification
 
-If you specify `SERVICE_EUREKA_ELBV2_HOSTNAME=` and `SERVICE_EUREKA_ELBV2_PORT=` values on the container, then these will be used, rather than a lookup attempted.
+If you specify `SERVICE_EUREKA_ELBV2_HOSTNAME=`, `SERVICE_EUREKA_ELBV2_PORT=` and `SERVICE_EUREKA_ELBV2_TARGETGROUP=` values on the container, then these will be used, rather than a lookup attempted.
 
-If you specify the lookup flag, and also add these settings, the manual ones will take precedent.
+If you specify the lookup flag, and also add ALL of these settings, the manual ones will take precedent.
 
 ### AWS ELBv2 Only Registration
 

--- a/registrator.go
+++ b/registrator.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"strings"
@@ -31,7 +30,6 @@ var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establi
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
 var requireLabel = flag.Bool("require-label", false, "Only register containers which have the SERVICE_REGISTER label, and ignore all others.")
-var logLocation = flag.String("log", "", "Specify a location to write a log file to.  The file will be called registrator-HOSTNAME.log")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -52,22 +50,6 @@ func main() {
 		os.Exit(0)
 	}
 	flag.Parse()
-
-	if *logLocation != "" {
-		hostName, err := os.Hostname()
-		if err != nil || hostName == "" {
-			log.Fatalf("error getting hostname: %v", err)
-		}
-		fileName := *logLocation + fmt.Sprintf("/registrator-%s.log", hostName)
-		log.Printf("Writing log file to %s", fileName)
-		f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-		if err != nil {
-			log.Fatalf("error opening file: %v", err)
-		}
-		defer f.Close()
-		mw := io.MultiWriter(os.Stdout, f)
-		log.SetOutput(mw)
-	}
 
 	log.Printf("Starting registrator %s ...", Version)
 

--- a/run-registrator.sh
+++ b/run-registrator.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+LOG_FILE=/logs/registrator-$(hostname).log
+exec > >(tee -a ${LOG_FILE} )
+exec 2> >(tee -a ${LOG_FILE} >&2)
+
+# Startup registrator and capture log output
+# Needs to run inside the container
+
+CMD="/bin/registrator $@"
+echo Running: $CMD
+$CMD
+

--- a/run-registrator.sh
+++ b/run-registrator.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-LOG_FILE=/logs/registrator-$(hostname).log
+DATE=$(date +%d%m%Y-%H%M%S)
+LOG_FILE=/logs/registrator-$(hostname)-$DATE.log
 exec > >(tee -a ${LOG_FILE} )
 exec 2> >(tee -a ${LOG_FILE} >&2)
 

--- a/service-config/environment-sidecartest.yaml
+++ b/service-config/environment-sidecartest.yaml
@@ -2,6 +2,6 @@ environment: sidecartest
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-log","/logs","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-perftest-orch

--- a/service-config/environment-sidecartest.yaml
+++ b/service-config/environment-sidecartest.yaml
@@ -2,6 +2,6 @@ environment: sidecartest
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-resync","300","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-perftest-orch

--- a/service-config/environment-sidecartest.yaml
+++ b/service-config/environment-sidecartest.yaml
@@ -2,6 +2,6 @@ environment: sidecartest
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2", "2>&1", "|", "tee", "-a", "/logs/registrator-$HOSTNAME.log"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-perftest-orch

--- a/service-config/environment-sidecartest.yaml
+++ b/service-config/environment-sidecartest.yaml
@@ -2,6 +2,6 @@ environment: sidecartest
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-log","/logs","eureka://registrator-testing.thorhudl.com:8080/eureka/v2", "-log", "/logs"]
     preferences:
       ecsCluster: t-marvel-perftest-orch

--- a/service-config/environment-sidecartest.yaml
+++ b/service-config/environment-sidecartest.yaml
@@ -2,6 +2,6 @@ environment: sidecartest
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-log","/logs","eureka://registrator-testing.thorhudl.com:8080/eureka/v2", "-log", "/logs"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-log","/logs","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-perftest-orch

--- a/service-config/environment-sidecartest.yaml
+++ b/service-config/environment-sidecartest.yaml
@@ -2,6 +2,6 @@ environment: sidecartest
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2", "2>&1", "|", "tee", "-a", "/logs/registrator-$HOSTNAME.log"]
     preferences:
       ecsCluster: t-marvel-perftest-orch

--- a/service-config/environment-thormaster.yaml
+++ b/service-config/environment-thormaster.yaml
@@ -2,6 +2,6 @@ environment: thormaster
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-log","/logs","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-ecs

--- a/service-config/environment-thormaster.yaml
+++ b/service-config/environment-thormaster.yaml
@@ -2,6 +2,6 @@ environment: thormaster
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-resync","300","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-ecs

--- a/service-config/environment-thormaster.yaml
+++ b/service-config/environment-thormaster.yaml
@@ -2,6 +2,6 @@ environment: thormaster
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-log","/logs","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-ecs

--- a/service-config/environment-thormaster.yaml
+++ b/service-config/environment-thormaster.yaml
@@ -2,6 +2,6 @@ environment: thormaster
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2", "2>&1", "|", "tee", "-a", "/logs/registrator-$HOSTNAME.log"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-ecs

--- a/service-config/environment-thormaster.yaml
+++ b/service-config/environment-thormaster.yaml
@@ -2,6 +2,6 @@ environment: thormaster
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2", "2>&1", "|", "tee", "-a", "/logs/registrator-$HOSTNAME.log"]
     preferences:
       ecsCluster: t-marvel-ecs

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -5,6 +5,10 @@ service:
   tribe: foundation
 infrastructure:
   web:
+    preference:
+      environment_variables:
+      - SERVICE_EUREKA_lookup_elbv2_endpoint: false
+      - SERVICE_REGISTER: true
     requirements:
       cpu_units: 10
       soft_memory_limit: 128

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -7,8 +7,8 @@ infrastructure:
   web:
     preferences:
       environment_variables:
-      - SERVICE_EUREKA_lookup_elbv2_endpoint: false
-      - SERVICE_REGISTER: true
+      - SERVICE_EUREKA_lookup_elbv2_endpoint: "false"
+      - SERVICE_REGISTER: "true"
     requirements:
       cpu_units: 10
       soft_memory_limit: 128

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -5,7 +5,7 @@ service:
   tribe: foundation
 infrastructure:
   web:
-    preference:
+    preferences:
       environment_variables:
       - SERVICE_EUREKA_lookup_elbv2_endpoint: false
       - SERVICE_REGISTER: true


### PR DESCRIPTION
Add new checks to make sure there is a healthy container when registering a new ELB

- If there are no healthy containers when initially registered, register ELB as status STARTING.
- On each subsequent heartbeat, check the target group again for healthy containers, reregister with status UP if one or more is available.
- Additionally tee the log file to /logs/registrator-$HOSTNAME.log inside the container.  In practice this hostname will be the container ID, or a short version of it.  This should then allow logs to flow into sumo given previous changes already made for the log volume. 

*Optimisations:*

- [x] The target group health is only cached for 10s at the moment, so it will get looked up every heartbeat (this is intentional to make sure the ALB registers as UP as quickly as possible).  `GetHealthyTargets` is called each heartbeat until the status changes to UP.  If we have issues with rate limiting (probably won't) then we could increase the caching time.

*Configuration*

- [ ] Do we want to be able to disable the option entirely?
- [x] Do we need to be able to set the retry time, or can it be just set to one heartbeat interval?  This requires adding a new go routine if it's faster than every heartbeat interval, so would make the code rather more complicated.
- [ ] Do we need to be able to control the number of retries so that it doesn't check with every healthcheck, for the rest of time, if a target group never recovers?  We could perhaps put the ALB in as DOWN if it failed to get healthy containers soon enough (and give us a way of finding these problems through eureka).

Testing
- [x] Do we hit any AWS rate limiting issues?  This should be better than other areas as we are only retrieving a single target group for each container, every 15s or so.
- [x] Does it register in eureka as intended, in the STARTING state?
- [ ] Does it fairly quickly change to the UP state, once a healthy container appears?