### PR TITLE
Add stage and prod envrionments

### DIFF
--- a/service-config/environment-prod.yaml
+++ b/service-config/environment-prod.yaml
@@ -1,0 +1,7 @@
+environment: prod
+infrastructure:
+  web:
+    requirements:
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-resync","300","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
+    preferences:
+      ecsCluster: p-marvel-ecs

--- a/service-config/environment-stage.yaml
+++ b/service-config/environment-stage.yaml
@@ -1,0 +1,7 @@
+environment: stage
+infrastructure:
+  web:
+    requirements:
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-resync","300","eureka://eureka.app.staghudl.com:8080/eureka/v2"]
+    preferences:
+      ecsCluster: s-marvel-ecs

--- a/service-config/environment-testsidecar.yaml
+++ b/service-config/environment-testsidecar.yaml
@@ -1,4 +1,4 @@
-environment: sidecartest
+environment: testsidecar
 infrastructure:
   web:
     requirements:


### PR DESCRIPTION
Add the stage and prod environment files.

NOTE: Prod is currently set to the thor eureka server, just for safety.  It can be changed manually by creating a new task definition version at go-live time.