### PR TITLE
Reduce chances of throttling of AWS API, making ELBv2 lookups more efficient

### DIFF
--- a/Dockerfile.race
+++ b/Dockerfile.race
@@ -1,6 +1,9 @@
 FROM golang:1.7
-ENTRYPOINT ["/bin/registrator"]
+ENTRYPOINT ["/bin/run-registrator.sh"]
 
+RUN mkdir /logs
+COPY ./run-registrator.sh /bin
+RUN chmod 755 /bin/run-registrator.sh
 COPY . /go/src/github.com/gliderlabs/registrator
 RUN cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DEV_RUN_OPTS ?=-ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1  eureka://localhost:8090/eureka/v2
+DEV_RUN_OPTS ?=-ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1 -resync 30 eureka://localhost:8090/eureka/v2
 PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
 

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -10,6 +10,7 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 
 	"github.com/gliderlabs/registrator/bridge"
@@ -25,8 +26,10 @@ type LBInfo struct {
 }
 
 type lookupValues struct {
-	InstanceID string
-	Port       int64
+	InstanceID  string
+	Port        int64
+	ClusterName string
+	TaskArn     string
 }
 
 const DEFAULT_EXP_TIME = 10 * time.Second
@@ -77,6 +80,64 @@ func getSession() (*elbv2.ELBV2, error) {
 	return elbv2.New(sess, awssdk.NewConfig().WithRegion(awsMetadata.Region)), nil
 }
 
+func getECSSession() (*ecs.ECS, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		message := fmt.Errorf("Failed to create session connecting to AWS: %s", err)
+		return nil, message
+	}
+
+	// Need to set the region here - we'll get it from instance metadata
+	return ecs.New(sess, awssdk.NewConfig().WithRegion("us-east-1")), nil
+}
+
+// Get Load balancer and target group using a service and cluster name (more efficient)
+func getLoadBalancerFromService(serviceName string, clusterName string) (*elbv2.LoadBalancer, *elbv2.TargetGroup, error) {
+
+	dsi := ecs.DescribeServicesInput{
+		Cluster:  &clusterName,
+		Services: []*string{&serviceName},
+	}
+
+	svc, err := getECSSession()
+	if err != nil {
+		return nil, nil, err
+	}
+	svc2, err := getSession()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out, err := svc.DescribeServices(&dsi)
+	if err != nil || out == nil {
+		log.Printf("An error occurred using DescribeServices: %s \n", err.Error())
+		return nil, nil, err
+	}
+	tgArn := out.Services[0].LoadBalancers[0].TargetGroupArn
+
+	// Get the target group listed for the service
+	dtgI := elbv2.DescribeTargetGroupsInput{
+		TargetGroupArns: []*string{tgArn},
+	}
+	out3, err := svc2.DescribeTargetGroups(&dtgI)
+	if err != nil || out3 == nil {
+		log.Printf("An error occurred using DescribeTargetGroups: %s \n", err.Error())
+		return nil, nil, err
+	}
+
+	// Get the load balancer details
+	dlbI := elbv2.DescribeLoadBalancersInput{
+		LoadBalancerArns: out3.TargetGroups[0].LoadBalancerArns,
+	}
+	out2, err := svc2.DescribeLoadBalancers(&dlbI)
+	if err != nil || out2 == nil {
+		log.Printf("An error occurred using DescribeLoadBalancers: %s \n", err.Error())
+		return nil, nil, err
+	}
+
+	return out2.LoadBalancers[0], out3.TargetGroups[0], nil
+}
+
 // Helper function to retrieve all target groups
 func getAllTargetGroups(svc *elbv2.ELBV2) ([]*elbv2.DescribeTargetGroupsOutput, error) {
 	var tgs []*elbv2.DescribeTargetGroupsOutput
@@ -124,8 +185,8 @@ func getTargetGroupsPage(svc *elbv2.ELBV2, marker *string) (*elbv2.DescribeTarge
 // if an error occurs, or the target is not found, an empty LBInfo is returned.
 // Pass it the instanceID for the docker host, and the the host port to lookup the associated ELB.
 //
-func GetELBV2ForContainer(containerID string, instanceID string, port int64) (lbinfo *LBInfo, err error) {
-	i := lookupValues{InstanceID: instanceID, Port: port}
+func GetELBV2ForContainer(containerID string, instanceID string, port int64, clusterName string, taskArn string) (lbinfo *LBInfo, err error) {
+	i := lookupValues{InstanceID: instanceID, Port: port, ClusterName: clusterName, TaskArn: taskArn}
 	out, err := getAndCache(containerID, i, getLB, gocache.NoExpiration)
 	if out == nil || err != nil {
 		return nil, err
@@ -178,6 +239,66 @@ func getHealthyTargets(tgArn string) (ths []*elbv2.TargetHealthDescription, err 
 	return healthyTargets, nil
 }
 
+// Lookup the service name from the ECS cluster and taskArn.  A bit janky, but works.
+// Would be nice if amazon just put the service name as a label on the container.
+func lookupServiceName(clusterName string, taskArn string) string {
+
+	log.Printf("Looking up service with cluster: %s and taskArn: %s", clusterName, taskArn)
+	svc, err := getECSSession()
+	if err != nil {
+		log.Printf("Unable to get ECS session: %s", err)
+		return ""
+	}
+
+	dti := ecs.DescribeTasksInput{
+		Cluster: &clusterName,
+		Tasks:   []*string{&taskArn},
+	}
+
+	lsi := ecs.ListServicesInput{
+		Cluster: &clusterName,
+	}
+
+	var servicesList []*string
+	err = svc.ListServicesPages(&lsi,
+		func(page *ecs.ListServicesOutput, lastPage bool) bool {
+			for _, s := range page.ServiceArns {
+				servicesList = append(servicesList, s)
+			}
+			return !lastPage
+		})
+	if err != nil || servicesList == nil {
+		log.Printf("Error occurred using ListServicesPages: %s", err)
+		return ""
+	}
+
+	dsi := ecs.DescribeServicesInput{
+		Cluster:  &clusterName,
+		Services: servicesList,
+	}
+
+	dtout, err := svc.DescribeTasks(&dti)
+	if err != nil || dtout == nil || len(dtout.Tasks) == 0 {
+		log.Printf("Error occurred using DescribeTasks: %s", err)
+		return ""
+	}
+	taskDefArn := dtout.Tasks[0].TaskDefinitionArn
+	log.Printf("Task definition is: %v", *taskDefArn)
+
+	dsout, err := svc.DescribeServices(&dsi)
+	if err != nil || dsout == nil {
+		log.Printf("Error occurred using DescribeServices: %s", err)
+		return ""
+	}
+	for _, ser := range dsout.Services {
+		if *ser.TaskDefinition == *taskDefArn {
+			return *ser.ServiceName
+		}
+	}
+	log.Printf("Service could not be identified")
+	return ""
+}
+
 //
 // Does the real work of retrieving the load balancer details, given a lookupValues struct.
 // Note: This function uses caching extensively to reduce the burden on the AWS API when called from multiple goroutines
@@ -190,6 +311,8 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 	var lbPort *int64
 	var tgArn string
 	info := &LBInfo{}
+	var clusterName string
+	var serviceName string
 
 	// Small random wait to reduce risk of throttling
 	seed := rand.NewSource(time.Now().UnixNano())
@@ -204,52 +327,70 @@ func getLB(l lookupValues) (lbinfo *LBInfo, err error) {
 		return nil, err
 	}
 
-	// TODO Note: There could be thousands of these, and we need to check them all.  Seems to be no
-	// other way to retrieve a TG via instance/port with current API
-
-	out1, err := getAndCache("tg", svc, getAllTargetGroups, DEFAULT_EXP_TIME)
-	if err != nil || out1 == nil {
-		message := fmt.Errorf("Failed to retrieve Target Groups: %s", err)
-		return nil, message
+	// We've got a clusterName and taskArn so we can lookup the service
+	if l.ClusterName != "" && l.TaskArn != "" {
+		serviceName = lookupServiceName(l.ClusterName, l.TaskArn)
+		clusterName = l.ClusterName
 	}
-	tgslice, _ := out1.([]*elbv2.DescribeTargetGroupsOutput)
 
-	// Check each target group's target list for a matching port and instanceID
-	// Assumption: that that there is only one LB for the target group (though the data structure allows more)
-	for _, tgs := range tgslice {
-		log.Printf("%v target groups to check.", len(tgs.TargetGroups))
-		for _, tg := range tgs.TargetGroups {
+	var tgslice []*elbv2.DescribeTargetGroupsOutput
+	if serviceName == "" {
+		// There could be thousands of these, and we need to check them all.
+		// much better to have a service name to use.
 
-			thParams := &elbv2.DescribeTargetHealthInput{
-				TargetGroupArn: awssdk.String(*tg.TargetGroupArn),
-			}
+		out1, err := getAndCache("tg", svc, getAllTargetGroups, DEFAULT_EXP_TIME)
+		if err != nil || out1 == nil {
+			message := fmt.Errorf("Failed to retrieve Target Groups: %s", err)
+			return nil, message
+		}
+		tgslice, _ = out1.([]*elbv2.DescribeTargetGroupsOutput)
 
-			out2, err := getAndCache(*thParams.TargetGroupArn, thParams, svc.DescribeTargetHealth, DEFAULT_EXP_TIME)
-			if err != nil || out2 == nil {
-				log.Printf("An error occurred using DescribeTargetHealth: %s \n", err.Error())
-				return nil, err
-			}
-			tarH, ok := out2.(*elbv2.DescribeTargetHealthOutput)
-			if !ok || tarH.TargetHealthDescriptions == nil {
-				continue
-			}
-			for _, thd := range tarH.TargetHealthDescriptions {
-				if *thd.Target.Port == port && *thd.Target.Id == instanceID {
-					log.Printf("Target group matched - %v", *tg.TargetGroupArn)
-					lbArns = tg.LoadBalancerArns
-					tgArn = *tg.TargetGroupArn
-					break
+		// Check each target group's target list for a matching port and instanceID
+		// Assumption: that that there is only one LB for the target group (though the data structure allows more)
+		for _, tgs := range tgslice {
+			log.Printf("%v target groups to check.", len(tgs.TargetGroups))
+			for _, tg := range tgs.TargetGroups {
+
+				thParams := &elbv2.DescribeTargetHealthInput{
+					TargetGroupArn: awssdk.String(*tg.TargetGroupArn),
+				}
+
+				out2, err := getAndCache(*thParams.TargetGroupArn, thParams, svc.DescribeTargetHealth, DEFAULT_EXP_TIME)
+				if err != nil || out2 == nil {
+					log.Printf("An error occurred using DescribeTargetHealth: %s \n", err.Error())
+					return nil, err
+				}
+				tarH, ok := out2.(*elbv2.DescribeTargetHealthOutput)
+				if !ok || tarH.TargetHealthDescriptions == nil {
+					continue
+				}
+				for _, thd := range tarH.TargetHealthDescriptions {
+					if *thd.Target.Port == port && *thd.Target.Id == instanceID {
+						log.Printf("Target group matched - %v", *tg.TargetGroupArn)
+						lbArns = tg.LoadBalancerArns
+						tgArn = *tg.TargetGroupArn
+						break
+					}
 				}
 			}
+			if lbArns != nil && tgArn != "" {
+				break
+			}
 		}
-		if lbArns != nil && tgArn != "" {
-			break
-		}
-	}
 
-	if err != nil || lbArns == nil {
-		message := fmt.Errorf("failed to retrieve load balancer ARN")
-		return nil, message
+		if err != nil || lbArns == nil {
+			message := fmt.Errorf("failed to retrieve load balancer ARN")
+			return nil, message
+		}
+
+	} else {
+		// We have the service and cluster name to use
+		lb, tg, err := getLoadBalancerFromService(serviceName, clusterName)
+		if lb == nil || tg == nil || err != nil {
+			return nil, err
+		}
+		tgArn = *tg.TargetGroupArn
+		lbArns = []*string{lb.LoadBalancerArn}
 	}
 
 	// Loop through the load balancer listeners to get the listener port for the target group
@@ -372,8 +513,18 @@ func setRegInfo(service *bridge.Service, registration *fargo.Instance) *fargo.In
 
 	} else {
 		// We don't have the ELB endpoint, so look it up.
+		// Check for some ECS labels first, these will allow more efficient lookups
+		var clusterName string
+		var taskArn string
 
-		elbMetadata1, err := GetELBV2ForContainer(service.Origin.ContainerID, awsMetadata.InstanceID, int64(registration.Port))
+		if service.Attrs["com.amazonaws.ecs.cluster"] != "" {
+			clusterName = service.Attrs["com.amazonaws.ecs.cluster"]
+		}
+		if service.Attrs["com.amazonaws.ecs.task-arn"] != "" {
+			taskArn = service.Attrs["com.amazonaws.ecs.task-arn"]
+		}
+
+		elbMetadata1, err := GetELBV2ForContainer(service.Origin.ContainerID, awsMetadata.InstanceID, int64(registration.Port), clusterName, taskArn)
 		if err != nil || elbMetadata1 == nil {
 			log.Printf("Unable to find associated ELBv2 for service: %s, instance: %s hostname: %s port: %v, Error: %s\n", service.Name, awsMetadata.InstanceID, registration.HostName, registration.Port, err)
 			return nil

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -319,6 +319,7 @@ func lookupServiceName(clusterName string, taskArn string) string {
 	log.Printf("Task definition is: %v", *taskDefArn)
 
 	// Lookup using maximum chunks of 10 service names
+	var matchedServices []*string
 	var servChunk []*string
 	for i := 0; i < len(servicesList); i++ {
 
@@ -337,11 +338,18 @@ func lookupServiceName(clusterName string, taskArn string) string {
 			}
 			for _, ser := range dsout.Services {
 				if *ser.TaskDefinition == *taskDefArn {
-					return *ser.ServiceName
+					matchedServices = append(matchedServices, ser.ServiceName)
 				}
 			}
 			servChunk = nil
 		}
+	}
+	if len(matchedServices) == 1 {
+		return *matchedServices[0]
+	}
+	if len(matchedServices) > 1 {
+		log.Printf("More than one service matches the task definition.  Cannot use fast lookup.")
+		return ""
 	}
 	log.Printf("Service could not be identified")
 	return ""

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -55,15 +55,15 @@ func (e HasNoLoadBalancer) Error() string {
 // Make eureka status thread-safe
 //
 type eurekaStatus struct {
-	sync.Mutex
+	sync.RWMutex
 	Mapper map[string]fargo.StatusType
 }
 
 var previousStatus = eurekaStatus{Mapper: make(map[string]fargo.StatusType)}
 
 func getPreviousStatus(containerID string) fargo.StatusType {
-	previousStatus.Lock()
-	defer previousStatus.Unlock()
+	previousStatus.RLock()
+	defer previousStatus.RUnlock()
 	return previousStatus.Mapper[containerID]
 }
 

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -561,6 +561,10 @@ func setRegInfo(service *bridge.Service, registration *fargo.Instance) *fargo.In
 		registration.SetMetadataString("aws-instance-id", "")
 	}
 
+	// Reduce lease time for ALBs to have them drop out of eureka quicker
+	registration.LeaseInfo = fargo.LeaseInfo{
+		DurationInSecs: 35,
+	}
 	registration.SetMetadataString("has-elbv2", "true")
 	registration.SetMetadataString("elbv2-endpoint", elbEndpoint)
 	registration.VipAddress = registration.IPAddr

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -121,7 +121,8 @@ func getECSSession() (*ecs.ECS, error) {
 	}
 
 	// Need to set the region here - we'll get it from instance metadata
-	return ecs.New(sess, awssdk.NewConfig().WithRegion("us-east-1")), nil
+	awsMetadata := GetMetadata()
+	return ecs.New(sess, awssdk.NewConfig().WithRegion(awsMetadata.Region)), nil
 }
 
 // Get Load balancer and target group using a service and cluster name (more efficient)

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -115,6 +115,8 @@ func Test_GetELBV2ForContainer(t *testing.T) {
 	type args struct {
 		containerID string
 		instanceID  string
+		cluster     string
+		task        string
 		port        int64
 	}
 	tests := []struct {
@@ -125,7 +127,7 @@ func Test_GetELBV2ForContainer(t *testing.T) {
 	}{
 		{
 			name:       "should match",
-			args:       args{containerID: "123123412", instanceID: "instance-123", port: int64(1234)},
+			args:       args{containerID: "123123412", instanceID: "instance-123", port: int64(1234), cluster: "cluster", task: "task"},
 			wantErr:    false,
 			wantLbinfo: &lbWant,
 		},
@@ -133,7 +135,7 @@ func Test_GetELBV2ForContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLbinfo, err := GetELBV2ForContainer(tt.args.containerID, tt.args.instanceID, tt.args.port)
+			gotLbinfo, err := GetELBV2ForContainer(tt.args.containerID, tt.args.instanceID, tt.args.port, tt.args.cluster, tt.args.task)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetELBV2ForContainer() error = %+v, wantErr %+v", err, tt.wantErr)
 				return
@@ -323,9 +325,13 @@ func Test_setRegInfo(t *testing.T) {
 		Name:     eureka.Amazon,
 		Metadata: wantedAwsInfo,
 	}
+	wantedLeaseInfo := eureka.LeaseInfo{
+		DurationInSecs: 35,
+	}
 
 	wanted := eureka.Instance{
 		DataCenterInfo: wantedDCInfo,
+		LeaseInfo:      wantedLeaseInfo,
 		Port:           int(lb.Port),
 		App:            svc.Name,
 		IPAddr:         "",
@@ -399,6 +405,9 @@ func Test_setRegInfoExplicitEndpoint(t *testing.T) {
 		Name:     eureka.Amazon,
 		Metadata: awsInfo,
 	}
+	wantedLeaseInfo := eureka.LeaseInfo{
+		DurationInSecs: 35,
+	}
 
 	reg := eureka.Instance{
 		DataCenterInfo: dcInfo,
@@ -429,6 +438,7 @@ func Test_setRegInfoExplicitEndpoint(t *testing.T) {
 	expectedPort, _ := strconv.Atoi(svc.Attrs["eureka_elbv2_port"])
 	wanted := eureka.Instance{
 		DataCenterInfo: wantedDCInfo,
+		LeaseInfo:      wantedLeaseInfo,
 		Port:           expectedPort,
 		App:            svc.Name,
 		IPAddr:         "",
@@ -500,6 +510,9 @@ func Test_setRegInfoELBv2Only(t *testing.T) {
 		Name:     eureka.Amazon,
 		Metadata: awsInfo,
 	}
+	wantedLeaseInfo := eureka.LeaseInfo{
+		DurationInSecs: 35,
+	}
 
 	rawMdInput := []byte(`<is-container>true</is-container>
 		<container-id>container-id-goes-here</container-id>
@@ -547,6 +560,7 @@ func Test_setRegInfoELBv2Only(t *testing.T) {
 
 	wanted := eureka.Instance{
 		DataCenterInfo: wantedDCInfo,
+		LeaseInfo:      wantedLeaseInfo,
 		Port:           int(lb.Port),
 		App:            svc.Name,
 		IPAddr:         "",

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -116,6 +116,7 @@ func Test_GetELBV2ForContainer(t *testing.T) {
 		containerID string
 		instanceID  string
 		cluster     string
+		service     string
 		task        string
 		port        int64
 	}
@@ -135,7 +136,7 @@ func Test_GetELBV2ForContainer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotLbinfo, err := GetELBV2ForContainer(tt.args.containerID, tt.args.instanceID, tt.args.port, tt.args.cluster, tt.args.task)
+			gotLbinfo, err := GetELBV2ForContainer(tt.args.containerID, tt.args.instanceID, tt.args.port, tt.args.cluster, tt.args.task, tt.args.service)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetELBV2ForContainer() error = %+v, wantErr %+v", err, tt.wantErr)
 				return

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -106,6 +106,9 @@ func (b *Bridge) getServicesCopy() map[string][]*Service {
 
 func (b *Bridge) Sync(quiet bool) {
 
+	// Take this to avoid having to use a mutex
+	servicesSnapshot := b.getServicesCopy()
+
 	containers, err := b.docker.ListContainers(dockerapi.ListContainersOptions{})
 	if err != nil && quiet {
 		log.Println("error listing containers, skipping sync")
@@ -113,9 +116,6 @@ func (b *Bridge) Sync(quiet bool) {
 	} else if err != nil && !quiet {
 		log.Fatal(err)
 	}
-
-	// Take this to avoid having to use a mutex
-	servicesSnapshot := b.getServicesCopy()
 
 	log.Printf("Syncing services on %d containers", len(containers))
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -209,8 +209,6 @@ func (b *Bridge) deleteDeadContainer(containerId string) {
 }
 
 func (b *Bridge) appendService(containerId string, service *Service) {
-	b.Lock()
-	defer b.Unlock()
 	b.services[containerId] = append(b.services[containerId], service)
 	log.Println("added:", containerId[:12], service.ID)
 }
@@ -218,7 +216,10 @@ func (b *Bridge) appendService(containerId string, service *Service) {
 func (b *Bridge) add(containerId string, quiet bool) {
 	b.deleteDeadContainer(containerId)
 
-	if b.getServicesCopy()[containerId] != nil {
+	b.Lock()
+	defer b.Unlock()
+
+	if b.services[containerId] != nil {
 		log.Println("container, ", containerId[:12], ", already exists, ignoring")
 		// Alternatively, remove and readd or resubmit.
 		return

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -209,6 +209,12 @@ func (b *Bridge) deleteDeadContainer(containerId string) {
 }
 
 func (b *Bridge) appendService(containerId string, service *Service) {
+	b.Lock()
+	defer b.Unlock()
+	if b.services[containerId] != nil {
+		log.Println("container, ", containerId[:12], ", already exists, will not append.")
+		return
+	}
 	b.services[containerId] = append(b.services[containerId], service)
 	log.Println("added:", containerId[:12], service.ID)
 }
@@ -224,6 +230,7 @@ func (b *Bridge) add(containerId string, quiet bool) {
 		// Alternatively, remove and readd or resubmit.
 		return
 	}
+	b.Unlock()
 
 	container, err := b.docker.InspectContainer(containerId)
 	if err != nil {

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -223,8 +223,6 @@ func (b *Bridge) add(containerId string, quiet bool) {
 	b.deleteDeadContainer(containerId)
 
 	b.Lock()
-	defer b.Unlock()
-
 	if b.services[containerId] != nil {
 		log.Println("container, ", containerId[:12], ", already exists, ignoring")
 		// Alternatively, remove and readd or resubmit.

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -371,6 +371,13 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 			mapDefault(metadata, "tags", ""), b.config.ForceTags)
 	}
 
+	// Look for ECS labels and add them to metadata if present
+	for k, v := range container.Config.Labels {
+		if strings.Contains(k, "com.amazonaws.ecs") {
+			metadata[k] = v
+		}
+	}
+
 	id := mapDefault(metadata, "id", "")
 	if id != "" {
 		service.ID = id

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -208,6 +208,7 @@ SERVICE_EUREKA_ELBV2_HOSTNAME = If set, will explicitly be used as the ELBv2 hos
 SERVICE_EUREKA_ELBV2_PORT = If set, will be explicitly used as the ELBv2 Port - see below.
 SERVICE_EUREKA_ELBV2_TARGETGROUP = If set, will be explicitly used as the ELBv2 TargetGroup - see below.
 SERVICE_EUREKA_ELBV2_ONLY_REGISTRATION = true (if false then adding the ELB hostname and port to each individual container registration will happen).
+SERVICE_EUREKA_ECS_SERVICE = If set, will make the ELBv2 lookups more efficient on ECS.  Should be set to the ECS service name string.
 ```
 
 AWS datacenter metadata will be automatically populated.  _However_, the `InstanceID` will instead be the unique identifier `Host_Port`.  This is due to limitations in the eureka server and fargo library.  

--- a/docs/user/backends.md
+++ b/docs/user/backends.md
@@ -210,7 +210,7 @@ SERVICE_EUREKA_ELBV2_TARGETGROUP = If set, will be explicitly used as the ELBv2 
 SERVICE_EUREKA_ELBV2_ONLY_REGISTRATION = true (if false then adding the ELB hostname and port to each individual container registration will happen).
 ```
 
-AWS datacenter metadata will be automatically populated.  _However_, the `InstanceID` will instead match `hostName`, which is the unique identifier for the container (Host_Port).  This is due to limitations in the eureka server.  
+AWS datacenter metadata will be automatically populated.  _However_, the `InstanceID` will instead be the unique identifier `Host_Port`.  This is due to limitations in the eureka server and fargo library.  
 Instead, a new metadata tag, `aws_instanceID` has the underlying host instanceID.
 
 For any of this to work, it requires properly functioning IAM roles for your container host.  On ECS, this will just work  - however, if you are running custom container hosts on EC2 with kubernetes or the like, then it may need further setup for the AWS metadata to work.
@@ -269,7 +269,14 @@ In order for this to work (you will receive a log error if not) the IAM role att
                 "elasticloadbalancing:DescribeTags",
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetHealth"
+                "elasticloadbalancing:DescribeTargetHealth",
+                "ecs:DescribeClusters",
+                "ecs:DescribeServices",
+                "ecs:DescribeTaskDefinition",
+                "ecs:DescribeTasks",
+                "ecs:ListClusters",
+                "ecs:ListServices",
+                "ecs:ListTasks"
             ],
             "Resource": [
                 "*"

--- a/service-config/environment-prod.yaml
+++ b/service-config/environment-prod.yaml
@@ -2,6 +2,6 @@ environment: prod
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-resync","300","eureka://eureka.app.hudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-cleanup","-resync","300","eureka://eureka.app.hudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: p-marvel-ecs

--- a/service-config/environment-stage.yaml
+++ b/service-config/environment-stage.yaml
@@ -2,6 +2,6 @@ environment: stage
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-resync","300","eureka://eureka.app.staghudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-cleanup","-resync","300","eureka://eureka.app.staghudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: s-marvel-ecs

--- a/service-config/environment-testsidecar.yaml
+++ b/service-config/environment-testsidecar.yaml
@@ -2,6 +2,6 @@ environment: testsidecar
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-resync","300","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-resync","300","-cleanup","-require-label","eureka://registrator-testing.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-perftest-orch

--- a/service-config/environment-thor.yaml
+++ b/service-config/environment-thor.yaml
@@ -1,4 +1,4 @@
-environment: thormaster
+environment: thor
 infrastructure:
   web:
     requirements:

--- a/service-config/environment-thor.yaml
+++ b/service-config/environment-thor.yaml
@@ -2,6 +2,6 @@ environment: thor
 infrastructure:
   web:
     requirements:
-      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-resync","300","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
+      docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-cleanup","-resync","300","eureka://classic-eureka.vpc.thorhudl.com:8080/eureka/v2"]
     preferences:
       ecsCluster: t-marvel-ecs

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -4,6 +4,12 @@ service:
   name:  registrator
   tribe: foundation
 infrastructure:
+infrastructure:
+  placement_constraints:
+  - type: distinctInstance
+  deployment_options:
+    minimum_healthy_percent: 50
+    maximum_percent: 200
   web:
     preferences:
       environment_variables:

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -24,7 +24,7 @@ infrastructure:
       log_paths:
       - sourceCategory: app_registrator
         pathExpression: /var/log/app_registrator/**
-        dateFormat: yyyy/MM/dd hh24:mi:ss
+        dateFormat: yyyy-MM-dd HH:mm:ss
       volumes:
       - name: log
         host_path: /var/log/app_registrator

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -8,7 +8,7 @@ infrastructure:
   - type: distinctInstance
   deployment_options:
     minimum_healthy_percent: 50
-    maximum_percent: 200
+    maximum_percent: 100
   web:
     preferences:
       environment_variables:

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -4,7 +4,6 @@ service:
   name:  registrator
   tribe: foundation
 infrastructure:
-infrastructure:
   placement_constraints:
   - type: distinctInstance
   deployment_options:


### PR DESCRIPTION
Improve the efficiency of ELBv2 lookups by using some ECS labels to identify the cluster and service.

- Add all labels starting `com.amazonaws.ecs` to the service attributes.
- Check for `com.amazonaws.ecs.cluster` and `com.amazonaws.ecs.task-arn`.  If present, these can be used to lookup the service name.  This  and the cluster name are then used to retrieve the target group and load balancer details, rather than looping through all target groups.
- If these labels aren't present, then previous behaviour is preserved.
- A fix to try to help behaviour around ALB dropouts - there may have been a data race between resync and refresh (heartbeat)

Tests:

- [x] Does registrator consistently and reliably retrieve the load balancer with the new method?
- [x]  Fails back to old method when there are multiple services with the same task definition and version.  This should not be an issue with marvel services though because of how marvel deploy works.
- [x] Handles incorrectly configured services which have the ELBv2 lookup flag set but no ELB.
- [x] Are there any issues with throttling when many services are present?
- [x] Do ALBs consistently and correctly leave eureka after the container stops?