### PR TITLE
Swap go-dockerclient for Moby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add -t build-deps build-base go git \
 	&& apk --no-cache add ca-certificates bash coreutils \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \
-  && git config --global http.https://gopkg.in.followRedirects true \
+	&& git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
 	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
 	&& rm -rf /go \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ ENV GOPATH /go
 COPY ./run-registrator.sh /bin
 RUN chmod 755 /bin/run-registrator.sh
 COPY . /go/src/github.com/gliderlabs/registrator
-RUN apk --no-cache add -t build-deps build-base go git \
+RUN apk --no-cache add -t build-deps build-base go git glide \
 	&& apk --no-cache add ca-certificates bash coreutils \
 	&& cd /go/src/github.com/gliderlabs/registrator \
 	&& export GOPATH=/go \
 	&& git config --global http.https://gopkg.in.followRedirects true \
-	&& go get \
+	&& glide install -v \
 	&& go build -ldflags "-X main.Version=$(cat VERSION)" -o /bin/registrator \
 	&& rm -rf /go \
 	&& apk del --purge build-deps 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,7 +7,8 @@ COPY ./run-registrator.sh /bin
 RUN chmod 755 /bin/run-registrator.sh
 RUN apk --no-cache add build-base go coreutils git ca-certificates bash
 COPY . /go/src/github.com/gliderlabs/registrator
+
 RUN cd /go/src/github.com/gliderlabs/registrator \
-  && git config --global http.https://gopkg.in.followRedirects true \
+	&& git config --global http.https://gopkg.in.followRedirects true \
 	&& go get \
 	&& go build -ldflags "-X main.Version=dev" -o /bin/registrator

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,10 +5,10 @@ RUN mkdir /logs
 ENV GOPATH /go
 COPY ./run-registrator.sh /bin
 RUN chmod 755 /bin/run-registrator.sh
-RUN apk --no-cache add build-base go coreutils git ca-certificates bash
+RUN apk --no-cache add build-base go coreutils git ca-certificates bash glide
 COPY . /go/src/github.com/gliderlabs/registrator
 
 RUN cd /go/src/github.com/gliderlabs/registrator \
 	&& git config --global http.https://gopkg.in.followRedirects true \
-	&& go get \
+	&& glide install
 	&& go build -ldflags "-X main.Version=dev" -o /bin/registrator

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
 DEPEND=github.com/Masterminds/glide
 
+.PHONY: clean depend build
+
 prep-dev: teardown
 	docker kill reg_eureka; echo Stopped.
 	docker run --rm --name reg_eureka -e "SERVICE_REGISTER=true" -td -p 8090:8080 netflixoss/eureka:1.1.147
@@ -38,3 +40,13 @@ release:
 depend:
 	go get -v $(DEPEND)
 	glide install
+
+clean:
+	if [ -a vendor/ ] ; \
+	then \
+	     rm -R vendor/ ; \
+	fi;
+	if [ -a registrator ] ; \
+	then \
+	     rm registrator ; \
+	fi;

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,26 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DEV_RUN_OPTS ?=-ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1 -resync 30 eureka://localhost:8090/eureka/v2
+DEV_RUN_OPTS ?=-ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1 -resync 30 eureka://127.0.0.1:8090/eureka/v2
 PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
+DEPEND=github.com/Masterminds/glide
 
-dev:
+prep-dev: teardown
 	docker kill reg_eureka; echo Stopped.
 	docker run --rm --name reg_eureka -e "SERVICE_REGISTER=true" -td -p 8090:8080 netflixoss/eureka:1.1.147
 	docker build -f Dockerfile.dev -t $(NAME):dev .
+
+dev-run:
 	docker run -ti --rm \
 		--net=host \
 		-v /var/run/docker.sock:/tmp/docker.sock \
 		$(NAME):dev $(DEV_RUN_OPTS)
+
+teardown:
 	docker kill reg_eureka
+
+dev: prep-dev dev-run teardown
 
 build:
 	mkdir -p build
@@ -28,3 +35,6 @@ release:
 	docker build -t $(PROD_RELEASE_TAG) .
 	docker push $(PROD_RELEASE_TAG)
 
+depend:
+	go get -v $(DEPEND)
+	glide install

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -4,7 +4,7 @@ package bridge
 import (
 	"net/url"
 
-	dockerapi "github.com/fsouza/go-dockerclient"
+	dockertypes "github.com/docker/docker/api/types"
 )
 
 type AdapterFactory interface {
@@ -57,5 +57,5 @@ type ServicePort struct {
 	ContainerHostname string
 	ContainerID       string
 	ContainerName     string
-	container         *dockerapi.Container
+	container         *dockertypes.ContainerJSON
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,161 @@
+hash: c5a0b53d9aa7760ea08e092f41551ab33ec56d9c73d2d6dc6d9f6771187ab78d
+updated: 2017-07-14T13:46:52.534996451-05:00
+imports:
+- name: github.com/aws/aws-sdk-go
+  version: 1fd5dd46e2bf3e0be156701a559098dc823053d5
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - internal/shareddefaults
+  - private/protocol
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/xml/xmlutil
+  - service/ecs
+  - service/elbv2
+  - service/sts
+- name: github.com/cenkalti/backoff
+  version: 32cd0c5b3aef12c76ed64aaf678f6c79736be7dc
+- name: github.com/clbanning/x2j
+  version: 5ee34bb343f10ecfc125261107681de62f985cf6
+- name: github.com/coreos/go-etcd
+  version: f02171fbd43c7b9b53ce8679b03235a1ef3c7b12
+  subpackages:
+  - etcd
+- name: github.com/docker/distribution
+  version: f86db6b22663a27ba4d278220b7e34be528b1e79
+  subpackages:
+  - digestset
+  - reference
+- name: github.com/docker/docker
+  version: 90d35abf7b3535c1c319c872900fbd76374e521c
+  subpackages:
+  - api
+  - api/types
+  - api/types/blkiodev
+  - api/types/container
+  - api/types/events
+  - api/types/filters
+  - api/types/image
+  - api/types/mount
+  - api/types/network
+  - api/types/registry
+  - api/types/strslice
+  - api/types/swarm
+  - api/types/time
+  - api/types/versions
+  - api/types/volume
+  - client
+  - pkg/ioutils
+  - pkg/longpath
+  - pkg/system
+  - pkg/tlsconfig
+- name: github.com/docker/go-connections
+  version: 990a1a1a70b0da4c4cb70e117971a4f0babfbf1a
+  subpackages:
+  - nat
+  - sockets
+  - tlsconfig
+- name: github.com/docker/go-units
+  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/docker/libtrust
+  version: aabc10ec26b754e797f9028f4589c5b7bd90dc20
+- name: github.com/franela/goreq
+  version: 9df54ca75ad62b6295f33ca96e16a2ca10bc137a
+- name: github.com/gliderlabs/pkg
+  version: 36f28d47ec7aae4d25d3d2741ac5af91f7f18680
+  subpackages:
+  - usage
+- name: github.com/go-ini/ini
+  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
+- name: github.com/hashicorp/consul
+  version: 2c7715154d8d4568524b76d2d4deb7ca6fd1b285
+  subpackages:
+  - api
+- name: github.com/hashicorp/go-cleanhttp
+  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+- name: github.com/hashicorp/go-rootcerts
+  version: 6bb64b370b90e7ef1fa532be9e591a81c3493e00
+- name: github.com/hashicorp/serf
+  version: bbeddf0b3ab3072a60525afbd6b6f47d33839eee
+  subpackages:
+  - coordinate
+- name: github.com/hudl/fargo
+  version: 14ced469f7dc175f6fbf9f55d799f9f12e302965
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/Microsoft/go-winio
+  version: c4dc1301f1dc0307acd38e611aa375a64dfe0642
+- name: github.com/miekg/dns
+  version: 0559e6d230af0a3a7273853cb6994ebea21bfbe5
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+- name: github.com/op/go-logging
+  version: d2e44aa77b7195c0ef782189985dd8550e22e4de
+- name: github.com/opencontainers/go-digest
+  version: 279bed98673dd5bef374d3b6e4b09e2af76183bf
+- name: github.com/opencontainers/runc
+  version: a0159fddcd197a57790b6dd5654802b7dc8f80be
+  subpackages:
+  - libcontainer/user
+- name: github.com/patrickmn/go-cache
+  version: 1881a9bccb818787f68c52bfba648c6cf34c34fa
+- name: github.com/pkg/errors
+  version: c605e284fe17294bda444b34710735b29d1a9d90
+- name: github.com/samuel/go-zookeeper
+  version: 1d7be4effb13d2d908342d349d71a284a7542693
+  subpackages:
+  - zk
+- name: github.com/Sirupsen/logrus
+  version: 51dc0fc64317a2861273909081f9c315786533eb
+- name: golang.org/x/net
+  version: f01ecb60fe3835d80d9a0b7b2bf24b228c89260e
+  subpackages:
+  - context
+  - context/ctxhttp
+  - proxy
+- name: golang.org/x/sys
+  version: 4cd6d1a821c7175768725b55ca82f14683a29ea4
+  subpackages:
+  - unix
+  - windows
+- name: gopkg.in/coreos/go-etcd.v0
+  version: f02171fbd43c7b9b53ce8679b03235a1ef3c7b12
+  subpackages:
+  - etcd
+- name: gopkg.in/gcfg.v1
+  version: 0ef1a8547f99b94fac9af5377dd72febba18f37c
+  subpackages:
+  - scanner
+  - token
+  - types
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,63 @@
+package: github.com/gliderlabs/registrator
+subpackages:
+- aws
+- bridge
+- consul
+- consulkv
+- etcd
+- eureka
+- interfaces
+- skydns2
+- zookeeper
+flatten: true
+import:
+- package: github.com/aws/aws-sdk-go
+  version: ~1.10.10
+  subpackages:
+  - aws
+  - aws/ec2metadata
+  - aws/session
+  - service/ecs
+  - service/elbv2
+- package: github.com/cenkalti/backoff
+  version: ~1.0.0
+- package: github.com/coreos/go-etcd
+  version: ~2.0.0
+  subpackages:
+  - etcd
+- package: github.com/docker/docker
+  flatten: true
+  version: ~17.5.0-ce-rc3
+  subpackages:
+  - api/types
+  - api/types/container
+  - api/types/filters
+  - client
+- package: github.com/docker/go-connections
+  version: ~0.2.1
+  subpackages:
+  - nat
+- package: github.com/gliderlabs/pkg
+  subpackages:
+  - usage
+- package: github.com/hashicorp/consul
+  version: ~0.8.5
+  subpackages:
+  - api
+- package: github.com/hashicorp/go-cleanhttp
+- package: github.com/hudl/fargo
+  version: ~1.3.1
+- package: github.com/patrickmn/go-cache
+  version: ~2.0.0
+- package: github.com/samuel/go-zookeeper
+  subpackages:
+  - zk
+- package: gopkg.in/coreos/go-etcd.v0
+  version: ~2.0.0
+  subpackages:
+  - etcd
+testImport:
+- package: github.com/stretchr/testify
+  version: ~1.1.4
+  subpackages:
+  - assert

--- a/registrator.go
+++ b/registrator.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"strings"
 	"time"
+	"context"
 
-	dockerapi "github.com/fsouza/go-dockerclient"
+	dockerapi "github.com/docker/docker/client"
 	"github.com/gliderlabs/pkg/usage"
 	"github.com/gliderlabs/registrator/bridge"
+	dockertypes "github.com/docker/docker/api/types"
 )
 
 var Version string
@@ -95,7 +97,7 @@ func main() {
 		os.Setenv("DOCKER_HOST", "unix:///tmp/docker.sock")
 	}
 
-	docker, err := dockerapi.NewClientFromEnv()
+	docker, err := dockerapi.NewEnvClient()
 	assert(err)
 
 	if *deregister != "always" && *deregister != "on-success" {
@@ -134,8 +136,8 @@ func main() {
 	}
 
 	// Start event listener before listing containers to avoid missing anything
-	events := make(chan *dockerapi.APIEvents)
-	assert(docker.AddEventListener(events))
+	events, _ := docker.Events(context.Background(), dockertypes.EventsOptions{})
+	//assert(docker.AddEventListener(events))
 	log.Println("Listening for Docker events ...")
 
 	quit := make(chan struct{})


### PR DESCRIPTION
__Work in progress__ 
Previously it was using the go-dockerclient https://github.com/fsouza/go-dockerclient.  which we found a memory leak in.

This switches to use the official go client for docker, which is maintained here https://github.com/moby/moby/tree/master/client