### PR TITLE
Add Re-Register, fix ELB cache panic, add IP validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DEV_RUN_OPTS ?=-ttl 30 -ttl-refresh 15 -require-label -ip 127.0.0.1 eureka://127.0.0.1:8090/eureka/v2
+DEV_RUN_OPTS ?=-ttl 30 -ttl-refresh 15 -ip 127.0.0.1 -require-label  eureka://127.0.0.1:8090/eureka/v2
 PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DEV_RUN_OPTS ?=-ttl 60 -ttl-refresh 30 -require-label -ip 127.0.0.1 -resync 30 eureka://127.0.0.1:8090/eureka/v2
+DEV_RUN_OPTS ?=-ttl 30 -ttl-refresh 15 -require-label -ip 10.101.32.240 eureka://127.0.0.1:8090/eureka/v2
 PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
 
 prep-dev: teardown
-	docker run --rm --name reg_eureka -e "SERVICE_REGISTER=true" -td -p 8090:8080 netflixoss/eureka:1.1.147
+	docker run --rm --name reg_eureka -td -p 8090:8080 netflixoss/eureka:1.1.147
 	docker build -f Dockerfile.dev -t $(NAME):dev .
 
 teardown:
@@ -19,15 +19,22 @@ dev-run:
 	docker run -ti --rm \
 		--net=host \
 		-v /var/run/docker.sock:/tmp/docker.sock \
-		-e "FARGO_LOG_LEVEL=NOTICE"
+		-e "FARGO_LOG_LEVEL=NOTICE" \
 		$(NAME):dev $(DEV_RUN_OPTS)
+
+dev-run-resync:
+	docker run -ti --rm \
+		--net=host \
+		-v /var/run/docker.sock:/tmp/docker.sock \
+		-e "FARGO_LOG_LEVEL=NOTICE" \
+		$(NAME):dev -resync 30 $(DEV_RUN_OPTS)
 
 dev-run-verbose:
 	docker run -ti --rm \
 		--net=host \
 		-v /var/run/docker.sock:/tmp/docker.sock \
 		-e "REGISTRATOR_LOG_LEVEL=DEBUG" \
-		-e "FARGO_LOG_LEVEL=DEBUG"
+		-e "FARGO_LOG_LEVEL=DEBUG" \
 		$(NAME):dev $(DEV_RUN_OPTS)
 
 build:
@@ -42,3 +49,6 @@ test:
 release:
 	docker build -t $(PROD_RELEASE_TAG) .
 	docker push $(PROD_RELEASE_TAG)
+
+run-test-container:
+	docker run -d --entrypoint tail -e "SERVICE_REGISTER=true" -p 5000:5000 --rm busybox -f /dev/null

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DEV_RUN_OPTS ?=-ttl 30 -ttl-refresh 15 -require-label -ip 10.101.32.240 eureka://127.0.0.1:8090/eureka/v2
+DEV_RUN_OPTS ?=-ttl 30 -ttl-refresh 15 -require-label -ip 127.0.0.1 eureka://127.0.0.1:8090/eureka/v2
 PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
 

--- a/aws/elb.go
+++ b/aws/elb.go
@@ -650,10 +650,12 @@ func testStatus(containerID string, eurekaStatus fargo.StatusType, inputStatus f
 		result, found := generalCache.Get(containerID)
 		if !found {
 			log.Errorf("Unable to retrieve ELB data from cache.  Cannot check for healthy targets!")
+			return fargo.UNKNOWN, fargo.STARTING
 		}
 		elbMetadata, ok := result.(*LBInfo)
 		if !ok {
 			log.Errorf("Unable to convert LBInfo from cache.  Cannot check for healthy targets!")
+			return fargo.UNKNOWN, fargo.STARTING
 		}
 		log.Debugf("Looking up healthy targets for TG: %v", elbMetadata.TargetGroupArn)
 		thList, err2 := GetHealthyTargets(elbMetadata.TargetGroupArn)

--- a/aws/elb_test.go
+++ b/aws/elb_test.go
@@ -622,6 +622,7 @@ func Test_testHealth(t *testing.T) {
 	}
 	tgArn := "arn:1234"
 	containerID := "123123412"
+	invalidContainerID := "111111"
 
 	setupCache("123123412", "instance-123", "correct-lb-dnsname", int64(1234), int64(9001), tgArn, unhealthyTHDs)
 
@@ -651,6 +652,23 @@ func Test_testHealth(t *testing.T) {
 		wantedNow := eureka.UP
 
 		now, reg := testStatus(containerID, eurekaStatus, previousStatus)
+		if reg != wanted {
+			t.Errorf("Should return %v status for reg status.  Returned %v", wanted, reg)
+		}
+		if now != wantedNow {
+			t.Errorf("Should return %v status for previous status.  Returned %v", wantedNow, now)
+		}
+	})
+
+	t.Run("Should fail gracefully", func(t *testing.T) {
+		flushCache(tgArn)
+		setupTHDCache(tgArn, healthyTHDs)
+		previousStatus := eureka.UNKNOWN
+		eurekaStatus := eureka.UNKNOWN
+		wanted := eureka.STARTING
+		wantedNow := eureka.UNKNOWN
+
+		now, reg := testStatus(invalidContainerID, eurekaStatus, previousStatus)
 		if reg != wanted {
 			t.Errorf("Should return %v status for reg status.  Returned %v", wanted, reg)
 		}

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -198,6 +198,11 @@ func (r *EurekaAdapter) Refresh(service *bridge.Service) error {
 	} else {
 		err := r.client.HeartBeatInstance(registration)
 		if err != nil {
+			if strings.Contains(err.Error(), "heartbeat failed, rcode = 404") {
+				log.Info("Registration dropped out of eureka, reregistering:", GetUniqueID(*registration))
+				r.client.RegisterInstance(registration)
+				return nil
+			}
 			log.Error("Error occurred when heartbeating:", GetUniqueID(*registration))
 		} else {
 			log.Debug("Done heartbeating for:", GetUniqueID(*registration))

--- a/registrator.go
+++ b/registrator.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -53,7 +54,7 @@ func main() {
 		versionChecker.PrintVersion()
 		os.Exit(0)
 	}
-	
+
 	flag.Parse()
 
 	logging.Configure()
@@ -80,6 +81,11 @@ func main() {
 	}
 
 	if *hostIp != "" {
+		ipRegEx, _ := regexp.Compile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
+		if !ipRegEx.MatchString(*hostIp) {
+			fmt.Fprintf(os.Stderr, "Invalid IP address '%s', please use a valid address.\n", *hostIp)
+			os.Exit(2)
+		}
 		log.Debug("Forcing host IP to", *hostIp)
 	}
 

--- a/registrator.go
+++ b/registrator.go
@@ -81,6 +81,7 @@ func main() {
 	}
 
 	if *hostIp != "" {
+		// below IP regex was obtained from http://blog.markhatton.co.uk/2011/03/15/regular-expressions-for-ip-addresses-cidr-ranges-and-hostnames/
 		ipRegEx, _ := regexp.Compile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
 		if !ipRegEx.MatchString(*hostIp) {
 			fmt.Fprintf(os.Stderr, "Invalid IP address '%s', please use a valid address.\n", *hostIp)


### PR DESCRIPTION
This PR fixes 3 issues.

1) Registrator wasn't reregistering if a instance drops out of eureka.  This was causing an issue with local development when a user would wake their computer from sleep.  We now re-register if we receive a 404 from a heartbeat.

2) Registrator will cause a panic if no ELB data is returned from cache, which can happen if the ELB is deleted.  This adds a fix for that and a unit test.

3) Adds IP address validation
  