### PR TITLE
return value for checkBooleanFlag, rather than if exists or not

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: build
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
@@ -20,6 +21,7 @@ dev-run:
 		--net=host \
 		-v /var/run/docker.sock:/tmp/docker.sock \
 		-e "FARGO_LOG_LEVEL=NOTICE" \
+		-e "SERVICE_EUREKA_DATACENTERINFO_AUTO_POPULATE=false"
 		$(NAME):dev $(DEV_RUN_OPTS)
 
 dev-run-resync:

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -59,7 +59,7 @@ func checkBooleanFlag(service *bridge.Service, flag string) bool {
 			log.Errorf("eureka: %s must be valid boolean, was %v : %s", flag, v, err)
 			return false
 		}
-		return true
+		return v
 	}
 	return false
 }


### PR DESCRIPTION
checkBooleanFlag() was being used like it should return the value of the boolean.. but the function was written to check whether it is a boolean or not. If you had the value false, it would still return true.

This caused SERVICE_eureka_datacenterinfo_auto_populate: 'false' being set to register instances with a blank hostname, resulting in instance ids being  `_{port}`

This fixes that issue.