### PR TITLE
MARVEL-1257: Getting ip from ipify on local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 NAME=registrator
 VERSION=$(shell cat VERSION)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
-DEV_RUN_OPTS ?=-ttl 30 -ttl-refresh 15 -ip 127.0.0.1 -require-label  eureka://127.0.0.1:8090/eureka/v2
+DEV_RUN_OPTS ?=-ttl 30 -ttl-refresh 15 -require-label  eureka://127.0.0.1:8090/eureka/v2
 PROD_RELEASE_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:latest
 TEST_TAG=761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:$(BRANCH)
 
@@ -21,7 +21,7 @@ dev-run:
 		--net=host \
 		-v /var/run/docker.sock:/tmp/docker.sock \
 		-e "FARGO_LOG_LEVEL=NOTICE" \
-		-e "SERVICE_EUREKA_DATACENTERINFO_AUTO_POPULATE=false"
+		-e "SERVICE_EUREKA_DATACENTERINFO_AUTO_POPULATE=false" \
 		$(NAME):dev $(DEV_RUN_OPTS)
 
 dev-run-resync:

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -15,6 +15,7 @@ import (
 )
 
 var serviceIDPattern = regexp.MustCompile(`^(.+?):([a-zA-Z0-9][a-zA-Z0-9_.-]+):[0-9]+(?::udp)?$`)
+var LocalHostIp string
 
 type Bridge struct {
 	sync.Mutex

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -71,7 +71,7 @@ func (b *Bridge) Refresh() {
 	// Set hostIp if needed
 	if b.config.HostIp == "" && b.config.IpServer != "" {
 		b.config.HostIp = b.getIpFromServer()
-		log.Debug("Refresh: setting HostIp to", b.config.HostIp)
+		log.Info("Refresh: setting HostIp to", b.config.HostIp)
 	}
 
 	for containerId, services := range b.getServicesCopy() {
@@ -119,7 +119,7 @@ func (b *Bridge) Sync(quiet bool) {
 	// Set hostIp if needed
 	if b.config.HostIp == "" && b.config.IpServer != "" {
 		b.config.HostIp = b.getIpFromServer()
-		log.Debug("Sync: setting HostIp to", b.config.HostIp)
+		log.Info("Sync: setting HostIp to", b.config.HostIp)
 	}
 
 	// Take this to avoid having to use a mutex

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -71,6 +71,7 @@ func (b *Bridge) Refresh() {
 	// Set hostIp if needed
 	if b.config.HostIp == "" && b.config.IpServer != "" {
 		b.config.HostIp = b.getIpFromServer()
+		log.Debug("Refresh: setting HostIp to", b.config.HostIp)
 	}
 
 	for containerId, services := range b.getServicesCopy() {
@@ -118,6 +119,7 @@ func (b *Bridge) Sync(quiet bool) {
 	// Set hostIp if needed
 	if b.config.HostIp == "" && b.config.IpServer != "" {
 		b.config.HostIp = b.getIpFromServer()
+		log.Debug("Sync: setting HostIp to", b.config.HostIp)
 	}
 
 	// Take this to avoid having to use a mutex

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -29,6 +29,7 @@ type Config struct {
 	DeregisterCheck string
 	Cleanup         bool
 	RequireLabel    bool
+	IpServer        string
 }
 
 type Service struct {

--- a/docs/user/run.md
+++ b/docs/user/run.md
@@ -37,6 +37,7 @@ Option                           | Since | Description
 `-deregister <mode>`             | v6    | Deregister existed services "always" or "on-success". Default: always
 `-internal`                      |       | Use exposed ports instead of published ports
 `-ip <ip address>`               |       | Force IP address used for registering services
+`-ip-server <ip server>`         |       | Get IP address from the specified server for registering services
 `-resync <seconds>`              | v6    | Frequency all services are resynchronized. Default: 0, never
 `-retry-attempts <number>`       | v7    | Max retry attempts to establish a connection with the backend
 `-retry-interval <milliseconds>` | v7    | Interval (in millisecond) between retry-attempts

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -1,9 +1,13 @@
 package eureka
 
 import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	aws "github.com/gliderlabs/registrator/aws"
 	"github.com/gliderlabs/registrator/bridge"
@@ -11,6 +15,7 @@ import (
 )
 
 const DefaultInterval = "10s"
+const Timeout time.Duration = time.Duration(5 * time.Second)
 
 func init() {
 	bridge.Register(new(Factory), "eureka")
@@ -111,6 +116,11 @@ func instanceInformation(service *bridge.Service) *fargo.Instance {
 		}
 	}
 
+	if !aws.CheckELBFlags(service) && bridge.LocalHostIp == "" {
+		//local dev
+		service.IP = getIPAddr()
+	}
+
 	// Metadata flag for a container
 	registration.SetMetadataString("is-container", string("true"))
 	registration.SetMetadataString("container-id", service.Origin.ContainerID)
@@ -134,6 +144,7 @@ func instanceInformation(service *bridge.Service) *fargo.Instance {
 		}
 		// Here we don't want auto population of metadata from AWS.  We'll use what we have from registrator, or overrides
 	} else if service.Attrs["eureka_datacenterinfo_name"] != fargo.MyOwn && !checkBooleanFlag(service, "eureka_datacenterinfo_auto_populate") {
+
 		registration.DataCenterInfo.Name = fargo.Amazon
 		registration.HostName = ShortHandTernary(service.Attrs["eureka_datacenterinfo_localhostname"], service.IP)
 		registration.DataCenterInfo.Metadata = fargo.AmazonMetadataType{
@@ -163,6 +174,26 @@ func instanceInformation(service *bridge.Service) *fargo.Instance {
 	return registration
 }
 
+func getIPAddr() string {
+	client := http.Client{
+		Timeout: Timeout,
+	}
+	resp, err := client.Get("http://ipify.app.thorhudl.com")
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+
+	defer resp.Body.Close()
+	responseData, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+
+	return string(responseData)
+}
+
 func (r *EurekaAdapter) Register(service *bridge.Service) error {
 	registration := instanceInformation(service)
 	var instance error
@@ -171,6 +202,7 @@ func (r *EurekaAdapter) Register(service *bridge.Service) error {
 		instance = aws.RegisterWithELBv2(service, registration, r.client)
 	} else {
 		log.Info("Registering instance", GetUniqueID(*registration))
+		log.Info("LocalHostIp: ", bridge.LocalHostIp)
 		instance = r.client.RegisterInstance(registration)
 	}
 	return instance

--- a/registrator.go
+++ b/registrator.go
@@ -24,6 +24,7 @@ var Version string
 var versionChecker = usage.NewChecker("registrator", Version)
 
 var hostIp = flag.String("ip", "", "IP for ports mapped to the host")
+var ipServer = flag.String("ip-server", "", "Get dynamic ip from the server for ports mapped to the host")
 var internal = flag.Bool("internal", false, "Use internal ports instead of published ones")
 var useIpFromLabel = flag.String("useIpFromLabel", "", "Use IP which is stored in a label assigned to the container")
 var refreshInterval = flag.Int("ttl-refresh", 0, "Frequency with which service TTLs are refreshed")
@@ -35,7 +36,6 @@ var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establi
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
 var requireLabel = flag.Bool("require-label", false, "Only register containers which have the SERVICE_REGISTER label, and ignore all others.")
-var ipServer = flag.String("ip-server", "", "Get dynamic ip from the server for ports mapped to the host")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {

--- a/registrator.go
+++ b/registrator.go
@@ -88,6 +88,7 @@ func main() {
 			os.Exit(2)
 		}
 		log.Debug("Forcing host IP to", *hostIp)
+		bridge.LocalHostIp = *hostIp
 	}
 
 	if *requireLabel {

--- a/registrator.go
+++ b/registrator.go
@@ -35,6 +35,7 @@ var retryAttempts = flag.Int("retry-attempts", 0, "Max retry attempts to establi
 var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) between retry-attempts.")
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
 var requireLabel = flag.Bool("require-label", false, "Only register containers which have the SERVICE_REGISTER label, and ignore all others.")
+var ipServer = flag.String("ip-server", "", "Get dynamic ip from the server for ports mapped to the host")
 
 func getopt(name, def string) string {
 	if env := os.Getenv(name); env != "" {
@@ -88,7 +89,6 @@ func main() {
 			os.Exit(2)
 		}
 		log.Debug("Forcing host IP to", *hostIp)
-		bridge.LocalHostIp = *hostIp
 	}
 
 	if *requireLabel {
@@ -127,6 +127,7 @@ func main() {
 		DeregisterCheck: *deregister,
 		Cleanup:         *cleanup,
 		RequireLabel:    *requireLabel,
+		IpServer:        *ipServer,
 	})
 
 	assert(err)


### PR DESCRIPTION
If the `-ip` arg is not found we'll get it from ipify instead. This is to remove the dependency on `.env`.

**Usage**
In docker-compose.yml, set `-ip-server`
```
  registrator:
    ...
    entrypoint: /bin/registrator -ttl 30 -ttl-refresh 15 -ip-server http://ipify.app.thorhudl.com -require-label eureka://eureka.app.thorhudl.com:8080/eureka/v2
```
This will produce
```
2018/06/25 19:28:31.375699 [path=eureka.go:26] [level=INFO] Connected to Eureka at http://eureka.app.thorhudl.com:8080/eureka/v2
2018/06/25 19:28:32.217974 [path=bridge.go:122] [level=INFO] Sync: setting HostIp to 172.16.10.26
2018/06/25 19:28:32.227416 [path=eureka.go:174] [level=INFO] Registering instance 172.16.10.26_32790
```

**TESTS**
- [x] (local) make a branch from a marvel service like playertracking, remove the `-ip...` param from docker-compose.yaml, run it locally, from t-warpdrive it should show the local dev ip. Disconnect vpn & reconnect (might need #it to kill off the session), on next sync the new ip should show up on Eureka.
- [x] (thor) spun up `t-sidecar-test` ecs cluster, setup this registrator branch on it, setup configurator on it also, then make a branch from a marvel service like playertracking, updated `config/service/environment-thor.yaml, infrastructure/web/preferences/ecsCluster to `t-sidecar-test`. Deploy that branch via Alyx3. Looking at t-warpdrive, it showed that on thor environment, registrator is using the ELB registration correctly.