### PR TITLE
Marvel-2323 Fix for ELB healthchecks when using load balancer labels

### DIFF
--- a/aws/cache.go
+++ b/aws/cache.go
@@ -32,6 +32,10 @@ func GetAndCache(key string, input Any, f Any, cacheTime time.Duration) (Any, er
 	return result, nil
 }
 
+func AddToCache(key string, value Any, cacheTime time.Duration) {
+	generalCache.Set(key, value, cacheTime)
+}
+
 // RemoveKeyFromCache : Delete any entry cache in the cache for this key
 func RemoveKeyFromCache(key string) {
 	generalCache.Delete(key)

--- a/aws/cache.go
+++ b/aws/cache.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"github.com/patrickmn/go-cache"
+	"reflect"
+	"time"
+)
+
+var generalCache = cache.New(DEFAULT_EXP_TIME, DEFAULT_EXP_TIME)
+
+type Any interface{}
+
+//
+// Provide a general caching mechanism for any function that lasts a few seconds.
+//
+func GetAndCache(key string, input Any, f Any, cacheTime time.Duration) (Any, error) {
+
+	vf := reflect.ValueOf(f)
+	vinput := reflect.ValueOf(input)
+
+	result, found := generalCache.Get(key)
+	if !found {
+		caller := vf.Call([]reflect.Value{vinput})
+		output := caller[0].Interface()
+		err, _ := caller[1].Interface().(error)
+		if err == nil {
+			generalCache.Set(key, output, cacheTime)
+			return output, nil
+		}
+		return nil, err
+	}
+	return result, nil
+}
+
+// RemoveKeyFromCache : Delete any entry cache in the cache for this key
+func RemoveKeyFromCache(key string) {
+	generalCache.Delete(key)
+}

--- a/aws/healthchecks.go
+++ b/aws/healthchecks.go
@@ -109,9 +109,9 @@ func determineNewEurekaStatus(containerID string, eurekaStatus fargo.StatusType,
 			log.Errorf("Unable to retrieve ELB data from cache.  Cannot check for healthy targets!")
 			return statusChange{newStatus: fargo.UNKNOWN, registrationStatus: fargo.STARTING}
 		}
-		elbMetadata, ok := result.(*LBInfo)
+		elbMetadata, ok := result.(*LoadBalancerRegistrationInfo)
 		if !ok {
-			log.Errorf("Unable to convert LBInfo from cache.  Cannot check for healthy targets!")
+			log.Errorf("Unable to convert LoadBalancerRegistrationInfo from cache.  Cannot check for healthy targets!")
 			return statusChange{newStatus: fargo.UNKNOWN, registrationStatus: fargo.STARTING}
 		}
 		log.Debugf("Looking up healthy targets for TG: %v", elbMetadata.TargetGroupArn)

--- a/aws/healthchecks.go
+++ b/aws/healthchecks.go
@@ -1,0 +1,131 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/gliderlabs/registrator/bridge"
+	"github.com/hudl/fargo"
+	"sync"
+	"time"
+)
+
+type statusChange struct {
+	registrationStatus fargo.StatusType
+	newStatus          fargo.StatusType
+}
+
+type eurekaStatus struct {
+	sync.RWMutex
+	Mapper map[string]fargo.StatusType
+}
+
+var previousStatus = eurekaStatus{Mapper: make(map[string]fargo.StatusType)}
+
+func getPreviousStatus(containerID string) fargo.StatusType {
+	previousStatus.RLock()
+	defer previousStatus.RUnlock()
+	return previousStatus.Mapper[containerID]
+}
+
+func setPreviousStatus(containerID string, status fargo.StatusType) {
+	previousStatus.Lock()
+	defer previousStatus.Unlock()
+	previousStatus.Mapper[containerID] = status
+}
+
+// GetHealthyTargets Get a list of healthy targets given a target group ARN.  Cache for default interval
+func GetHealthyTargets(tgArn string) (thds []*elbv2.TargetHealthDescription, err error) {
+	var healthCheckCacheTime time.Duration
+	if refreshInterval != 0 {
+		healthCheckCacheTime = (time.Duration(refreshInterval) * time.Second) - (1 * time.Second)
+	} else {
+		healthCheckCacheTime = DEFAULT_EXP_TIME
+	}
+
+	out, err := GetAndCache(tgArn, tgArn, getHealthyTargets, healthCheckCacheTime)
+	if out == nil || err != nil {
+		return nil, err
+	}
+	ret, _ := out.([]*elbv2.TargetHealthDescription)
+	return ret, err
+}
+
+// Actual func outside of caching mechanism
+func getHealthyTargets(tgArn string) (ths []*elbv2.TargetHealthDescription, err error) {
+	log.Debugf("Looking for healthy targets")
+	svc, err := getSession()
+	if err != nil {
+		return nil, err
+	}
+
+	thParams := &elbv2.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgArn),
+	}
+
+	tarH, err := svc.DescribeTargetHealth(thParams)
+	if err != nil || tarH == nil {
+		log.Errorf("An error occurred using DescribeTargetHealth: %s \n", err.Error())
+		return nil, err
+	}
+
+	var healthyTargets []*elbv2.TargetHealthDescription
+	for _, thd := range tarH.TargetHealthDescriptions {
+		if *thd.TargetHealth.State == "healthy" {
+			healthyTargets = append(healthyTargets, thd)
+		}
+	}
+	return healthyTargets, nil
+}
+
+// Test eureka registration status and mutate registration accordingly depending on container health.
+func testHealth(service *bridge.Service, client fargo.EurekaConnection, elbReg *fargo.Instance) {
+	containerID := service.Origin.ContainerID
+
+	// Get actual eureka status and lookup previous logical registration status
+	eurekaStatus := getELBStatus(client, elbReg)
+	log.Debugf("Eureka status check gave: %v", eurekaStatus)
+	last := getPreviousStatus(containerID)
+
+	// Work out an appropriate registration status given previous and current values
+	statusChange := determineNewEurekaStatus(containerID, eurekaStatus, last)
+	setPreviousStatus(containerID, statusChange.newStatus)
+	elbReg.Status = statusChange.registrationStatus
+	log.Debugf("Status health check returned prev: %v registration: %v", last, elbReg.Status)
+}
+
+// Return appropriate registration statuses based on previous status and cached ELB data
+func determineNewEurekaStatus(containerID string, eurekaStatus fargo.StatusType, inputStatus fargo.StatusType) (change statusChange) {
+
+	// Nothing to do if eureka says we're up, just return UP
+	if eurekaStatus == fargo.UP {
+		return statusChange{newStatus: fargo.UP, registrationStatus: fargo.UP}
+	}
+
+	if inputStatus != fargo.UP {
+		log.Debugf("Previous status was: %v, need to check for healthy targets.", inputStatus)
+		// The ELB data should be cached, so just get it from there.
+		result, found := generalCache.Get(containerID)
+		if !found {
+			log.Errorf("Unable to retrieve ELB data from cache.  Cannot check for healthy targets!")
+			return statusChange{newStatus: fargo.UNKNOWN, registrationStatus: fargo.STARTING}
+		}
+		elbMetadata, ok := result.(*LBInfo)
+		if !ok {
+			log.Errorf("Unable to convert LBInfo from cache.  Cannot check for healthy targets!")
+			return statusChange{newStatus: fargo.UNKNOWN, registrationStatus: fargo.STARTING}
+		}
+		log.Debugf("Looking up healthy targets for TG: %v", elbMetadata.TargetGroupArn)
+		thList, err2 := GetHealthyTargets(elbMetadata.TargetGroupArn)
+		if err2 != nil {
+			log.Errorf("An error occurred looking up healthy targets, for target group: %s, will set to STARTING in eureka. Error: %s\n", elbMetadata.TargetGroupArn, err2)
+			return statusChange{newStatus: fargo.UNKNOWN, registrationStatus: fargo.STARTING}
+		}
+		if len(thList) == 0 {
+			log.Infof("Waiting on a healthy target in TG: %s - currently all UNHEALTHY.  Setting eureka state to STARTING.  This is normal for a new service which is starting up.  It may indicate a problem otherwise.", elbMetadata.TargetGroupArn)
+			return statusChange{newStatus: fargo.STARTING, registrationStatus: fargo.STARTING}
+		}
+		log.Debugf("Found %v healthy targets for target group: %s.  Setting eureka state to UP.", len(thList), elbMetadata.TargetGroupArn)
+		return statusChange{newStatus: fargo.UP, registrationStatus: fargo.UP}
+	}
+	return statusChange{newStatus: fargo.UP, registrationStatus: fargo.UP}
+}

--- a/aws/healthchecks_test.go
+++ b/aws/healthchecks_test.go
@@ -1,10 +1,23 @@
 package aws
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hudl/fargo"
 	"testing"
+	gocache "github.com/patrickmn/go-cache"
 )
+
+
+// Setup the target health descriptions cache specifically
+func setupTHDCache(tgArn string, thds []*elbv2.TargetHealthDescription) {
+	fn2 := func(thds []*elbv2.TargetHealthDescription) ([]*elbv2.TargetHealthDescription, error) {
+		return thds, nil
+	}
+	GetAndCache(tgArn, thds, fn2, gocache.NoExpiration)
+	r, _ := generalCache.Get(tgArn)
+	fmt.Printf("THD Cache value now looks like this: %+v\n", r.([]*elbv2.TargetHealthDescription))
+}
 
 // Test_testHealth - Test that testHealth mutates the registration details correctly
 func Test_testHealth(t *testing.T) {
@@ -21,10 +34,10 @@ func Test_testHealth(t *testing.T) {
 	containerID := "123123412"
 	invalidContainerID := "111111"
 
-	setupCache("123123412", "instance-123", "correct-lb-dnsname", int64(1234), int64(9001), tgArn, unhealthyTHDs)
+	setupCache("123123412", "instance-123", "correct-lb-dnsname", 1234, 9001, tgArn, unhealthyTHDs)
 
 	t.Run("Should return STARTING because of unhealthy targets", func(t *testing.T) {
-		flushCache(tgArn)
+		RemoveKeyFromCache(tgArn)
 		setupTHDCache(tgArn, unhealthyTHDs)
 		var previousStatus fargo.StatusType
 		eurekaStatus := fargo.UNKNOWN
@@ -41,7 +54,7 @@ func Test_testHealth(t *testing.T) {
 	})
 
 	t.Run("Should return UP because of healthy targets 1", func(t *testing.T) {
-		flushCache(tgArn)
+		RemoveKeyFromCache(tgArn)
 		setupTHDCache(tgArn, healthyTHDs)
 		previousStatus := fargo.UNKNOWN
 		eurekaStatus := fargo.UNKNOWN
@@ -58,7 +71,7 @@ func Test_testHealth(t *testing.T) {
 	})
 
 	t.Run("Should fail gracefully", func(t *testing.T) {
-		flushCache(tgArn)
+		RemoveKeyFromCache(tgArn)
 		setupTHDCache(tgArn, healthyTHDs)
 		previousStatus := fargo.UNKNOWN
 		eurekaStatus := fargo.UNKNOWN
@@ -75,7 +88,7 @@ func Test_testHealth(t *testing.T) {
 	})
 
 	t.Run("Should return UP because of eureka status", func(t *testing.T) {
-		flushCache(tgArn)
+		RemoveKeyFromCache(tgArn)
 		setupTHDCache(tgArn, unhealthyTHDs)
 
 		previousStatus := fargo.UNKNOWN
@@ -93,7 +106,7 @@ func Test_testHealth(t *testing.T) {
 	})
 
 	t.Run("Should return UP because of healthy targets 2", func(t *testing.T) {
-		flushCache(tgArn)
+		RemoveKeyFromCache(tgArn)
 		setupTHDCache(tgArn, healthyTHDs)
 
 		previousStatus := fargo.STARTING
@@ -111,3 +124,4 @@ func Test_testHealth(t *testing.T) {
 	})
 
 }
+

--- a/aws/healthchecks_test.go
+++ b/aws/healthchecks_test.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hudl/fargo"
+	"testing"
+)
+
+// Test_testHealth - Test that testHealth mutates the registration details correctly
+func Test_testHealth(t *testing.T) {
+	initMetadata() // Used from metadata_test.go
+
+	port := "80"
+	unhealthyTHDs := []*elbv2.TargetHealthDescription{}
+	healthyTHDs := []*elbv2.TargetHealthDescription{
+		{
+			HealthCheckPort: &port,
+		},
+	}
+	tgArn := "arn:1234"
+	containerID := "123123412"
+	invalidContainerID := "111111"
+
+	setupCache("123123412", "instance-123", "correct-lb-dnsname", int64(1234), int64(9001), tgArn, unhealthyTHDs)
+
+	t.Run("Should return STARTING because of unhealthy targets", func(t *testing.T) {
+		flushCache(tgArn)
+		setupTHDCache(tgArn, unhealthyTHDs)
+		var previousStatus fargo.StatusType
+		eurekaStatus := fargo.UNKNOWN
+		wanted := fargo.STARTING
+		wantedNow := fargo.STARTING
+
+		change := determineNewEurekaStatus(containerID, eurekaStatus, previousStatus)
+		if change.registrationStatus != wanted {
+			t.Errorf("Should return %v status for reg status.  Returned %v", wanted, change.registrationStatus)
+		}
+		if change.newStatus != wantedNow {
+			t.Errorf("Should return %v status for previous status.  Returned %v", wantedNow, change.newStatus)
+		}
+	})
+
+	t.Run("Should return UP because of healthy targets 1", func(t *testing.T) {
+		flushCache(tgArn)
+		setupTHDCache(tgArn, healthyTHDs)
+		previousStatus := fargo.UNKNOWN
+		eurekaStatus := fargo.UNKNOWN
+		wanted := fargo.UP
+		wantedNow := fargo.UP
+
+		change := determineNewEurekaStatus(containerID, eurekaStatus, previousStatus)
+		if change.registrationStatus != wanted {
+			t.Errorf("Should return %v status for reg status.  Returned %v", wanted, change.registrationStatus)
+		}
+		if change.newStatus != wantedNow {
+			t.Errorf("Should return %v status for previous status.  Returned %v", wantedNow, change.newStatus)
+		}
+	})
+
+	t.Run("Should fail gracefully", func(t *testing.T) {
+		flushCache(tgArn)
+		setupTHDCache(tgArn, healthyTHDs)
+		previousStatus := fargo.UNKNOWN
+		eurekaStatus := fargo.UNKNOWN
+		wanted := fargo.STARTING
+		wantedNow := fargo.UNKNOWN
+
+		change := determineNewEurekaStatus(invalidContainerID, eurekaStatus, previousStatus)
+		if change.registrationStatus != wanted {
+			t.Errorf("Should return %v status for reg status.  Returned %v", wanted, change.registrationStatus)
+		}
+		if change.newStatus != wantedNow {
+			t.Errorf("Should return %v status for previous status.  Returned %v", wantedNow, change.newStatus)
+		}
+	})
+
+	t.Run("Should return UP because of eureka status", func(t *testing.T) {
+		flushCache(tgArn)
+		setupTHDCache(tgArn, unhealthyTHDs)
+
+		previousStatus := fargo.UNKNOWN
+		eurekaStatus := fargo.UP
+		wantedReg := fargo.UP
+		wantedNow := fargo.UP
+
+		change := determineNewEurekaStatus(containerID, eurekaStatus, previousStatus)
+		if change.registrationStatus != wantedReg {
+			t.Errorf("Should return %v status for reg status.  Returned %v", wantedReg, change.registrationStatus)
+		}
+		if change.newStatus != wantedNow {
+			t.Errorf("Should return %v status for previous status.  Returned %v", wantedNow, change.newStatus)
+		}
+	})
+
+	t.Run("Should return UP because of healthy targets 2", func(t *testing.T) {
+		flushCache(tgArn)
+		setupTHDCache(tgArn, healthyTHDs)
+
+		previousStatus := fargo.STARTING
+		eurekaStatus := fargo.STARTING
+		wantedReg := fargo.UP
+		wantedNow := fargo.UP
+
+		change := determineNewEurekaStatus(containerID, eurekaStatus, previousStatus)
+		if change.registrationStatus != wantedReg {
+			t.Errorf("Should return %v status for reg status.  Returned %v", wantedReg, change.registrationStatus)
+		}
+		if change.newStatus != wantedNow {
+			t.Errorf("Should return %v status for previous status.  Returned %v", wantedNow, change.newStatus)
+		}
+	})
+
+}

--- a/aws/structs.go
+++ b/aws/structs.go
@@ -1,0 +1,21 @@
+package aws
+
+type lookupValues struct {
+	InstanceID  string
+	Port        int64
+	ClusterName string
+	ServiceName string
+	TaskArn     string
+}
+
+// LBInfo represents a ELBv2 endpoint
+type LBInfo struct {
+	DNSName        string
+	Port           int64
+	TargetGroupArn string
+}
+
+// HasNoLoadBalancer - Special error type for when container has no load balancer
+type HasNoLoadBalancer struct {
+	message string
+}

--- a/aws/structs.go
+++ b/aws/structs.go
@@ -8,11 +8,14 @@ type lookupValues struct {
 	TaskArn     string
 }
 
-// LBInfo represents a ELBv2 endpoint
-type LBInfo struct {
+// LoadBalancerRegistrationInfo represents registration details for a ELBv2 endpoint
+type LoadBalancerRegistrationInfo struct {
 	DNSName        string
-	Port           int64
+	Port           int
+	ELBEndpoint    string
 	TargetGroupArn string
+	IpAddress      string
+	VipAddress     string
 }
 
 // HasNoLoadBalancer - Special error type for when container has no load balancer

--- a/build-image.sh
+++ b/build-image.sh
@@ -114,7 +114,7 @@ BUILD_RESULT=$?
 
 if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
     echo "Publishing ${REPOSITORY_AND_TAG}"
-    $(aws ecr get-login --region=us-east-1) 2>&1
+    $(aws ecr get-login --region=us-east-1 --no-include-email) 2>&1
 
     # Log success message for build failure condition
     docker push $REPOSITORY_AND_TAG && echo "Publish succeeded."

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -179,7 +179,7 @@ func (r *EurekaAdapter) Register(service *bridge.Service) error {
 func (r *EurekaAdapter) Deregister(service *bridge.Service) error {
 	registration := instanceInformation(service)
 	if aws.CheckELBFlags(service) {
-		aws.RemoveLBCache(service.Origin.ContainerID)
+		aws.RemoveKeyFromCache(service.Origin.ContainerID)
 	}
 	// Don't deregister ALB registrations.  Just leave them to expire if there are no heartbeats
 	if !aws.CheckELBFlags(service) {


### PR DESCRIPTION
This PR fixes a bug that healthchecks would fail when using labels/environment varables to set up load balancer details.  The problem was that the healthchecks use the cache to lookup the details.  The fix adds an entry to the 

There is also some refactoring, moving out the healthchecks code into it's own file, and 

- Move cache and healthchecks to their own files and out of elb.go
- Addition of `statusChange` struct for healthcheck results, to make them clearer (this area is well unit tested)
- Rename ELB methods for more clarity
- Breakdown `setRegInfo` by adding `getELBMetadata` method which returns a `LoadBalancerRegistrationInfo` struct.
- Rename `setRegInfo` to clearer `mutateRegistrationInfo` for clarity
- Update unit tests, and add an additional one around the bug fix.

Most of the code which was refactored is reasonably well covered by unit tests.  This will require a bit of manual testing on a eureka server though, so I will be testing on an isolated eureka server in thor before rollout.