### PR TITLE
WIP - MARVEL-2100 - Add logging to `registrator`

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -471,10 +471,5 @@ var Hostname string
 func init() {
 	// It's ok for Hostname to ultimately be an empty string
 	// An empty string will fall back to trying to make a best guess
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Errorf("Failed to get os.Hostname", err)
-	} else {
-		Hostname = hostname
-	}
+	Hostname, _ = os.Hostname()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+# Partial Compose to assist local debugging as opposed to Makefile
+version: '3'
+services:
+  eureka:
+    image: netflixoss/eureka:1.1.147
+  registrator:
+    depends_on:
+      - eureka
+    environment:
+        - FARGO_LOG_LEVEL=DEBUG
+        - REGISTRATOR_LOG_LEVEL=DEBUG
+        - SERVICE_EUREKA_DATACENTERINFO_AUTO_POPULATE=false
+        #- FARGO_LOG_LEVEL=DEBUG
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock
+    # Additional Options: -resync 30
+    command: "-ttl 30 -ttl-refresh 15 -ip 127.0.0.1 -require-label eureka://eureka:8080/eureka/v2"
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+  test_container:
+    image: busybox
+    depends_on:
+      - registrator
+    environment:
+      - SERVICE_REGISTER=true
+    command: "tail -f /dev/null"

--- a/service-config/environment-thor.yaml
+++ b/service-config/environment-thor.yaml
@@ -1,6 +1,9 @@
 environment: thor
 infrastructure:
   web:
+    preferences:
+      environment_variables:
+      - REGISTRATOR_LOG_LEVEL: "DEBUG"
     requirements:
       docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-cleanup","-resync","300","eureka://eureka.vpc2.thorhudl.com:8080/eureka/v2"]
     preferences:

--- a/service-config/environment-thor.yaml
+++ b/service-config/environment-thor.yaml
@@ -1,9 +1,6 @@
 environment: thor
 infrastructure:
   web:
-    preferences:
-      environment_variables:
-      - REGISTRATOR_LOG_LEVEL: "DEBUG"
     requirements:
       docker_command: ["-ttl","30","-ttl-refresh","15","-require-label","-cleanup","-resync","300","eureka://eureka.vpc2.thorhudl.com:8080/eureka/v2"]
     preferences:

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -9,7 +9,7 @@ infrastructure:
       environment_variables:
       - SERVICE_EUREKA_lookup_elbv2_endpoint: "false"
       - SERVICE_REGISTER: "false"
-      - REGISTRATOR_LOG_LEVEL: "INFO"
+      - REGISTRATOR_LOG_LEVEL: "DEBUG"
       - FARGO_LOG_LEVEL: "NOTICE"
     requirements:
       cpu_units: 10
@@ -42,7 +42,7 @@ infrastructure:
       - name: sys
         host_path: /sys
         container_path: /sys
-        read_only: true    
+        read_only: true
       - name: var_lib_docker
         host_path: /var/lib/docker/
         container_path: /var/lib/docker/

--- a/service-config/service.yaml
+++ b/service-config/service.yaml
@@ -9,7 +9,7 @@ infrastructure:
       environment_variables:
       - SERVICE_EUREKA_lookup_elbv2_endpoint: "false"
       - SERVICE_REGISTER: "false"
-      - REGISTRATOR_LOG_LEVEL: "DEBUG"
+      - REGISTRATOR_LOG_LEVEL: "INFO"
       - FARGO_LOG_LEVEL: "NOTICE"
     requirements:
       cpu_units: 10


### PR DESCRIPTION
## Overview

As per ticket MARVEL-2100 we have added additional logging, stopped ignoring some errors and added a global recover for any panics that somehow went under the radar.

## Contents
- `docker-compose.yml` file for easier debugging on Windows
- `recover()` deferred function added
- Additional logging
- Some ignored errors reinstated

## External related issues
Is it worth us upgrading to the official docker go SDK instead of third party? It may alleviate our issues.

