### PR TITLE
MARVEL-2583 - Use Exposed Ports

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -228,6 +228,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	metadata, metadataFromPort := serviceMetaData(container.Config, port.ExposedPort)
 
 	ignore := mapDefault(metadata, "ignore", "")
+	log.Info("Checking Ignore: %s", ignore)
 	if ignore != "" {
 		return nil
 	}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -172,9 +172,14 @@ func (b *Bridge) add(containerId string, quiet bool, newIP string) {
 	}
 
 	servicePorts := make(map[string]ServicePort)
+
 	for key, port := range ports {
-		// TODO: Put a check for the env var that sets up service.UseExposedPorts here and add the service ports if true
-		if b.config.Internal != true && port.HostPort == "" {
+		// Added a check for the env var that sets up service.UseExposedPorts here and add the service ports if true
+		log.Infof("looking up metadata for: %s", container.ID)
+		useExposedPorts := lookupMetaData(container.Config, "SERVICE_USE_EXPOSED_PORTS")
+		log.Infof("useExposedPorts: %s", useExposedPorts)
+
+		if !b.config.Internal && useExposedPorts != "" && port.HostPort == "" {
 			if !quiet {
 				log.Debug("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
 			}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -179,7 +179,7 @@ func (b *Bridge) add(containerId string, quiet bool, newIP string) {
 		useExposedPorts := lookupMetaData(container.Config, "SERVICE_USE_EXPOSED_PORTS")
 		log.Infof("useExposedPorts: %s", useExposedPorts)
 
-		if !b.config.Internal && useExposedPorts != "" && port.HostPort == "" {
+		if !b.config.Internal && useExposedPorts == "" && port.HostPort == "" {
 			if !quiet {
 				log.Debug("ignored:", container.ID[:12], "port", port.ExposedPort, "not published on host")
 			}

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -34,14 +34,14 @@ type Config struct {
 
 type Service struct {
 	sync.RWMutex
-	ID    string
-	Name  string
-	Port  int
-	IP    string
-	Tags  []string
-	Attrs map[string]string
-	TTL   int
-
+	ID    			string
+	Name  			string
+	Port  			int
+	IP    			string
+	UseExposedPorts	bool
+	Tags  			[]string
+	Attrs 			map[string]string
+	TTL   			int
 	Origin ServicePort
 }
 

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -76,6 +76,16 @@ func combineTags(tagParts ...string) []string {
 	return tags
 }
 
+func lookupMetaData(config *dockerapi.Config, key string) string {
+	for _, v := range config.Env {
+		str := strings.SplitN(v, "=", 2)
+		if strings.EqualFold(str[0], key) {
+			return str[1]
+		}
+	}
+	return ""
+}
+
 func serviceMetaData(config *dockerapi.Config, port string) (map[string]string, map[string]bool) {
 	meta := config.Labels
 


### PR DESCRIPTION
## Overview
This PR enables an additional config option via labels - `SERVICE_USE_EXPOSED_PORTS`. When this is provided it would utilise the exposed port on the container for registration as opposed to the Host port.

