### PR TITLE
MARVEL-2680 - Added retry and timeouts to the VPN IP Check

### DIFF
--- a/bridge/util.go
+++ b/bridge/util.go
@@ -5,12 +5,18 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cenkalti/backoff"
 	dockerapi "github.com/fsouza/go-dockerclient"
 )
 
 var ipLookupAddress = ""
+var ipLookupRetries = 0
+var ipRetryInterval = 10
+var client = http.Client{
+	Timeout: time.Duration(60 * time.Second),
+}
 
 func retry(fn func() error) error {
 	return backoff.Retry(fn, backoff.NewExponentialBackOff())
@@ -28,18 +34,50 @@ func SetExternalIPSource(lookupAddress string) {
 	ipLookupAddress = lookupAddress
 }
 
-func GetIPFromExternalSource() (string, error) {
-	res, err := http.Get(ipLookupAddress)
-	if err != nil {
-		log.Errorf("Failed to lookup IP Address from external source: %s", ipLookupAddress, err)
-		return "", err
+func SetIPLookupRetries(number int) {
+	ipLookupRetries = number
+}
+
+func lookupIp(address string) (*http.Response, error) {
+	return client.Get(address)
+}
+
+func GetIPFromExternalSource() (string, bool) {
+	_ip := []byte{}
+	attempt := 1
+	for attempt <= ipLookupRetries {
+		res, err := lookupIp(ipLookupAddress)
+		if err != nil {
+			log.Errorf("Failed to lookup IP Address from external source: %s. Waiting before attempting retry...", ipLookupAddress, err)
+			select {
+			case <-time.After(time.Duration(ipRetryInterval*attempt) * time.Second):
+				attempt++
+				continue
+			}
+		}
+
+		ip, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			log.Error("Failed to read body of lookup from external source. Attempting retry", err)
+
+			select {
+			case <-time.After(time.Duration(ipRetryInterval*attempt) * time.Second):
+				attempt++
+				continue
+			}
+		}
+
+		_ip = ip
+		break
 	}
-	ip, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		log.Error("Failed to read body of lookup from external source", err)
-		return "", err
+
+	if len(_ip) == 0 {
+		log.Error("All retries used when getting ip from external source.")
+		return "", false
 	}
-	return string(ip), nil
+	ipValue := string(_ip)
+	log.Infof("Success, returning ip: %s", ipValue)
+	return ipValue, true
 }
 
 // Golang regexp module does not support /(?!\\),/ syntax for spliting by not escaped comma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock
     # Additional Options: -resync 30
-    command: "-ttl 30 -ttl-refresh 15 -ip-lookup-source http://ipify.app.thorhudl.com/ -require-label eureka://eureka:8080/eureka/v2"
+    command: "-ttl 30 -ttl-refresh 15 -ip-lookup-source http://ipify.app.thorhudl.com/ -ip-lookup-retries 3 -require-label eureka://eureka:8080/eureka/v2"
     build:
       context: .
       dockerfile: Dockerfile.dev

--- a/registrator.go
+++ b/registrator.go
@@ -117,12 +117,13 @@ func main() {
 
 	var err error
 	if *ipLookupSource != "" {
+		log.Infof("ipLookupSource provided: %s", *ipLookupSource)
 		bridge.SetExternalIPSource(*ipLookupSource)
 		discoveredIP, success := bridge.GetIPFromExternalSource()
 		if !success {
 			os.Exit(2)
 		}
-		log.Infof("ipLookupSource provided. Deferring to external source for IP address. Current IP is: %s", discoveredIP)
+
 		if !ipRegEx.MatchString(discoveredIP) {
 			log.Error("Invalid IP address from ipLookupSource '%s', please use a valid address.\n", discoveredIP)
 		}

--- a/registrator.go
+++ b/registrator.go
@@ -36,6 +36,7 @@ var retryInterval = flag.Int("retry-interval", 2000, "Interval (in millisecond) 
 var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
 var requireLabel = flag.Bool("require-label", false, "Only register containers which have the SERVICE_REGISTER label, and ignore all others.")
 var ipLookupSource = flag.String("ip-lookup-source", "", "Used to configure IP lookup source. Useful when running locally")
+var ipLookupRetries = flag.Int("ip-lookup-retries", 1, "Used to set how many times it attempts to lookup the IP before exiting (default is 1)")
 
 // below IP regex was obtained from http://blog.markhatton.co.uk/2011/03/15/regular-expressions-for-ip-addresses-cidr-ranges-and-hostnames/
 var ipRegEx, _ = regexp.Compile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
@@ -106,13 +107,22 @@ func main() {
 		log.Info("SERVICE_REGISTER label is required to register containers.")
 	}
 
+	if *ipLookupRetries > 0 {
+		bridge.SetIPLookupRetries(*ipLookupRetries)
+		log.Infof("ipLookupRetries provided. Setting retries at %d", *ipLookupRetries)
+	} else {
+		log.Infof("ipLookupRetries needs to be set to at least 1")
+		os.Exit(2)
+	}
+
 	var err error
 	if *ipLookupSource != "" {
 		bridge.SetExternalIPSource(*ipLookupSource)
-		discoveredIP, err = bridge.GetIPFromExternalSource()
-		if err == nil {
-			log.Infof("ipLookupSource provided. Deferring to external source for IP address. Current IP is: %s", discoveredIP)
+		discoveredIP, success := bridge.GetIPFromExternalSource()
+		if !success {
+			os.Exit(2)
 		}
+		log.Infof("ipLookupSource provided. Deferring to external source for IP address. Current IP is: %s", discoveredIP)
 		if !ipRegEx.MatchString(discoveredIP) {
 			log.Error("Invalid IP address from ipLookupSource '%s', please use a valid address.\n", discoveredIP)
 		}
@@ -269,8 +279,11 @@ func main() {
 
 func resyncProcess(b *bridge.Bridge, ipLookupSource string) {
 	if ipLookupSource != "" {
-		temporaryIP, err := bridge.GetIPFromExternalSource()
-		if err == nil && (temporaryIP != discoveredIP) {
+		temporaryIP, success := bridge.GetIPFromExternalSource()
+		if !success {
+			os.Exit(2)
+		}
+		if temporaryIP != discoveredIP {
 			discoveredIP = temporaryIP
 			log.Infof("Network change has been detected by different IP. New IP is: %s", discoveredIP)
 			if !ipRegEx.MatchString(discoveredIP) {


### PR DESCRIPTION
## Overview
This PR adds retry logic (basic), introduce a HttpClient and a timeout, and a new config value, `ip-lookup-retries` which defaults to `1`. 

## Testing
Scenario: _Load up registrator with internet and see connection made. Load up without and see failure. On 3 failures exit. On 2 failures and reconnect reset and succeed._

- [x] Tested on Windows 
- [x] Tested on Mac
=============
- [x] Tested on Thor
- [x] Branch up for MicroserviceTemplate

