### PR TITLE
NOTICK - Resolve issue around `docker` events and resyncing ip's

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -49,8 +49,8 @@ func (b *Bridge) Ping() error {
 	return b.registry.Ping()
 }
 
-func (b *Bridge) Add(containerId string) {
-	b.add(containerId, false, "")
+func (b *Bridge) Add(containerId, ipToUse string) {
+	b.add(containerId, false, ipToUse)
 }
 
 func (b *Bridge) Remove(containerId string) {
@@ -133,6 +133,7 @@ func (b *Bridge) appendService(containerId string, service *Service) {
 }
 
 func (b *Bridge) add(containerId string, quiet bool, newIP string) {
+	log.Infof("Bridge.Add called with IP: %s", newIP)
 	b.deleteDeadContainer(containerId)
 
 	b.Lock()

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -170,7 +170,7 @@ func (r *EurekaAdapter) Register(service *bridge.Service) error {
 		log.Info("Registering ELB for instance", GetUniqueID(*registration))
 		instance = aws.RegisterWithELBv2(service, registration, r.client)
 	} else {
-		log.Info("Registering instance %s", service.Name, GetUniqueID(*registration))
+		log.Info("Registering instance", service.Name, GetUniqueID(*registration))
 		instance = r.client.RegisterInstance(registration)
 	}
 	return instance

--- a/eureka/eureka.go
+++ b/eureka/eureka.go
@@ -170,7 +170,7 @@ func (r *EurekaAdapter) Register(service *bridge.Service) error {
 		log.Info("Registering ELB for instance", GetUniqueID(*registration))
 		instance = aws.RegisterWithELBv2(service, registration, r.client)
 	} else {
-		log.Info("Registering instance", GetUniqueID(*registration))
+		log.Info("Registering instance %s", service.Name, GetUniqueID(*registration))
 		instance = r.client.RegisterInstance(registration)
 	}
 	return instance

--- a/registrator.go
+++ b/registrator.go
@@ -284,16 +284,14 @@ func resyncProcess(b *bridge.Bridge, ipLookupSource string) {
 		if !success {
 			os.Exit(2)
 		}
-		if temporaryIP != discoveredIP {
-			discoveredIP = temporaryIP
-			log.Infof("Network change has been detected by different IP. New IP is: %s", discoveredIP)
-			if !ipRegEx.MatchString(discoveredIP) {
-				fmt.Fprintf(os.Stderr, "Invalid IP when polling ipLookupSource '%s', please use a valid address.\n", discoveredIP)
-			} else {
-				go func(ip string, bridgeInstance *bridge.Bridge) {
-					b.AllocateNewIPToServices(ip)
-				}(discoveredIP, b)
-			}
+		discoveredIP = temporaryIP
+		log.Infof("Network change has been detected by different IP. New IP is: %s", discoveredIP)
+		if !ipRegEx.MatchString(discoveredIP) {
+			fmt.Fprintf(os.Stderr, "Invalid IP when polling ipLookupSource '%s', please use a valid address.\n", discoveredIP)
+		} else {
+			go func(ip string, bridgeInstance *bridge.Bridge) {
+				b.AllocateNewIPToServices(ip)
+			}(discoveredIP, b)
 		}
 	} else {
 		b.Sync(true)

--- a/registrator.go
+++ b/registrator.go
@@ -119,13 +119,14 @@ func main() {
 	if *ipLookupSource != "" {
 		log.Infof("ipLookupSource provided: %s", *ipLookupSource)
 		bridge.SetExternalIPSource(*ipLookupSource)
-		discoveredIP, success := bridge.GetIPFromExternalSource()
+		externalIPSource, success := bridge.GetIPFromExternalSource()
 		if !success {
 			os.Exit(2)
 		}
-
-		if !ipRegEx.MatchString(discoveredIP) {
-			log.Error("Invalid IP address from ipLookupSource '%s', please use a valid address.\n", discoveredIP)
+		if !ipRegEx.MatchString(externalIPSource) {
+			log.Error("Invalid IP address from ipLookupSource '%s', please use a valid address.\n", externalIPSource)
+		} else {
+			discoveredIP = externalIPSource
 		}
 	}
 

--- a/registrator.go
+++ b/registrator.go
@@ -270,7 +270,7 @@ func main() {
 		switch msg.Status {
 		case "start":
 			log.Debugf("Docker Event Received: Start %s", msg.ID)
-			go b.Add(msg.ID)
+			go b.Add(msg.ID, discoveredIP)
 		case "die":
 			log.Debugf("Docker Event Received: Die %s", msg.ID)
 			go b.RemoveOnExit(msg.ID)
@@ -285,7 +285,7 @@ func resyncProcess(b *bridge.Bridge, ipLookupSource string) {
 			os.Exit(2)
 		}
 		discoveredIP = temporaryIP
-		log.Infof("Network change has been detected by different IP. New IP is: %s", discoveredIP)
+		log.Infof("Resyncing process. IP to use is: %s", discoveredIP)
 		if !ipRegEx.MatchString(discoveredIP) {
 			fmt.Fprintf(os.Stderr, "Invalid IP when polling ipLookupSource '%s', please use a valid address.\n", discoveredIP)
 		} else {


### PR DESCRIPTION
## Overview
Ignoring the branch name, this is actually nothing to do with the metadata IP's and that is a red herring. The actual issue has probably been there since IP lookups from a source were added, and it has been plaguing people in various ways, we just suspect people have been dealing with it, nuking docker, containers etc.

## Fix Explained 
 In the event of a docker container being registered, it would take the container ID, look it up and grab it's IP and register it with that.
 If there was then a network change, it would re-register the service with the correct IP, however if there wasn't a network change you would end up with a service registered in Eureka with this phony IP indefinitely, short of restarting everything and re/connecting to VPN etc. 
 This has been resolved by now providing the IP with any docker event so at the very least if an IP source has an IP it will use that. In addition on resyncing, regardless of IP changes it will attempt to reregister unless the Application already is registered with it. With this two pronged strategy we shouldn't hit that scenario again.

## Acceptance Criteria
- [x] Tested on Mac
- [x] Tested on Windows
- [x] Tested on Reports/SwaggerUI etc (Known repos with later versions of `registrator`. For reports, to repro checkout `PST_upgrade-to-v0.8.4`)


Image:  `761584570493.dkr.ecr.us-east-1.amazonaws.com/registrator:NOTICK-RegIssueMetadataIP.20190503-1308.73efc0d.209`