### PR TITLE
Marvel-2837 Publish latest tag for master

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -116,7 +116,6 @@ if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
     echo "Publishing ${REPOSITORY_AND_TAG}"
     $(aws ecr get-login --region=us-east-1 --no-include-email) 2>&1
 
-    # TODO: Switch this to master!
     if [[ "$BRANCH" == "master" ]]; then
         echo Master branch detected. Will also publish to the latest tag.
         docker tag $REPOSITORY_AND_TAG $REPOSITORY:latest 

--- a/build-image.sh
+++ b/build-image.sh
@@ -121,10 +121,9 @@ if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
         docker tag $REPOSITORY_AND_TAG $REPOSITORY:latest 
         docker push $REPOSITORY:latest && echo "Publish latest succeeded."
         LATEST_PUSH_RESULT=$?
-        docker rmi $REPOSITORY_AND_TAG
+        docker rmi $REPOSITORY:latest
         if [ $LATEST_PUSH_RESULT -ne 0 ]; then
             docker rmi $REPOSITORY_AND_TAG
-            docker rmi $REPOSITORY:latest
             exit $LATEST_PUSH_RESULT
         fi
     fi

--- a/build-image.sh
+++ b/build-image.sh
@@ -116,8 +116,19 @@ if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
     echo "Publishing ${REPOSITORY_AND_TAG}"
     $(aws ecr get-login --region=us-east-1 --no-include-email) 2>&1
 
+    # TODO: Switch this to master!
+    if [[ "$BRANCH" == "MARVEL-2837-PublishLatest" ]]; then
+        docker push $REPOSITORY_AND_TAG $REPOSITORY:latest && echo "Publish latest succeeded."
+        LATEST_PUSH_RESULT=$?
+        docker rmi $REPOSITORY_AND_TAG
+        if [ $LATEST_PUSH_RESULT -ne 0 ]; then
+            docker rmi $REPOSITORY_AND_TAG
+            exit $LATEST_PUSH_RESULT
+        fi
+    fi
+
     # Log success message for build failure condition
-    docker push $REPOSITORY_AND_TAG && echo "Publish succeeded."
+    docker push $REPOSITORY_AND_TAG && echo "Publish version succeeded."
     PUSH_RESULT=$?
 
     docker rmi $REPOSITORY_AND_TAG

--- a/build-image.sh
+++ b/build-image.sh
@@ -118,11 +118,13 @@ if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
 
     # TODO: Switch this to master!
     if [[ "$BRANCH" == "MARVEL-2837-PublishLatest" ]]; then
-        docker push $REPOSITORY_AND_TAG $REPOSITORY:latest && echo "Publish latest succeeded."
+        docker tag $REPOSITORY_AND_TAG $REPOSITORY:latest 
+        docker push $REPOSITORY:latest && echo "Publish latest succeeded."
         LATEST_PUSH_RESULT=$?
         docker rmi $REPOSITORY_AND_TAG
         if [ $LATEST_PUSH_RESULT -ne 0 ]; then
             docker rmi $REPOSITORY_AND_TAG
+            docker rmi $REPOSITORY:latest
             exit $LATEST_PUSH_RESULT
         fi
     fi

--- a/build-image.sh
+++ b/build-image.sh
@@ -118,6 +118,7 @@ if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
 
     # TODO: Switch this to master!
     if [[ "$BRANCH" == "MARVEL-2837-PublishLatest" ]]; then
+        echo Master branch detected. Will also publish to the latest tag.
         docker tag $REPOSITORY_AND_TAG $REPOSITORY:latest 
         docker push $REPOSITORY:latest && echo "Publish latest succeeded."
         LATEST_PUSH_RESULT=$?

--- a/build-image.sh
+++ b/build-image.sh
@@ -117,7 +117,7 @@ if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
     $(aws ecr get-login --region=us-east-1 --no-include-email) 2>&1
 
     # TODO: Switch this to master!
-    if [[ "$BRANCH" == "MARVEL-2837-PublishLatest" ]]; then
+    if [[ "$BRANCH" == "master ]]; then
         echo Master branch detected. Will also publish to the latest tag.
         docker tag $REPOSITORY_AND_TAG $REPOSITORY:latest 
         docker push $REPOSITORY:latest && echo "Publish latest succeeded."

--- a/build-image.sh
+++ b/build-image.sh
@@ -117,7 +117,7 @@ if [ $BUILD_RESULT -eq 0 ] && [ $PUBLISH -eq 1 ]; then
     $(aws ecr get-login --region=us-east-1 --no-include-email) 2>&1
 
     # TODO: Switch this to master!
-    if [[ "$BRANCH" == "master ]]; then
+    if [[ "$BRANCH" == "master" ]]; then
         echo Master branch detected. Will also publish to the latest tag.
         docker tag $REPOSITORY_AND_TAG $REPOSITORY:latest 
         docker push $REPOSITORY:latest && echo "Publish latest succeeded."


### PR DESCRIPTION
This PR is a change for the build script, to publish master releases to the `latest` tag in ECR again.  This will allow marvel services to easily pull to the latest version and allow fixes to be rolled out more quickly.