### PR TITLE
MARVEL - Add Flag to not exit on inability to get IP address.

### DIFF
--- a/bridge/types.go
+++ b/bridge/types.go
@@ -30,7 +30,7 @@ type Config struct {
 	DeregisterCheck           string
 	Cleanup                   bool
 	RequireLabel              bool
-	ContinueOnIPLookupFailure bool
+	ExitOnIPLookupFailure     bool
 }
 
 type Service struct {

--- a/bridge/types.go
+++ b/bridge/types.go
@@ -21,15 +21,16 @@ type RegistryAdapter interface {
 }
 
 type Config struct {
-	HostIp          string
-	Internal        bool
-	UseIpFromLabel  string
-	ForceTags       string
-	RefreshTtl      int
-	RefreshInterval int
-	DeregisterCheck string
-	Cleanup         bool
-	RequireLabel    bool
+	HostIp                    string
+	Internal                  bool
+	UseIpFromLabel            string
+	ForceTags                 string
+	RefreshTtl                int
+	RefreshInterval           int
+	DeregisterCheck           string
+	Cleanup                   bool
+	RequireLabel              bool
+	ContinueOnIPLookupFailure bool
 }
 
 type Service struct {

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -40,8 +40,8 @@ func SetIPLookupRetries(number int) {
 }
 
 // ShouldContinueOnIPLookupFailure checks config if it should continue on ip failure.
-func ShouldContinueOnIPLookupFailure(b *Bridge) (bool) {
-	return b.config.ContinueOnIPLookupFailure
+func ShouldExitOnIPLookupFailure(b *Bridge) (bool) {
+	return b.config.ExitOnIPLookupFailure
 }
 
 func lookupIp(address string) (*http.Response, error) {

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -39,7 +39,7 @@ func SetIPLookupRetries(number int) {
 	ipLookupRetries = number
 }
 
-// ShouldContinueOnIPLookupFailure checks config if it should continue on ip failure.
+// ShouldExitOnIPLookupFailure checks config if it should exit on ip failure.
 func ShouldExitOnIPLookupFailure(b *Bridge) (bool) {
 	return b.config.ExitOnIPLookupFailure
 }

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -55,7 +55,7 @@ func GetIPFromExternalSource() (string, bool) {
 		res, err := lookupIp(ipLookupAddress)
 		var fail error
 		if err != nil {
-			fail = fmt.Errorf("Failed to lookup IP Address from external source: %s. Waiting before attempting retry...", ipLookupAddress, err)
+			fail = fmt.Errorf("Failed to lookup IP Address from external source: %s. Waiting before attempting retry... %s", ipLookupAddress, err)
 		} else {
 			ip, err := ioutil.ReadAll(res.Body)
 			if err != nil {

--- a/bridge/util.go
+++ b/bridge/util.go
@@ -39,6 +39,11 @@ func SetIPLookupRetries(number int) {
 	ipLookupRetries = number
 }
 
+// ShouldContinueOnIPLookupFailure checks config if it should continue on ip failure.
+func ShouldContinueOnIPLookupFailure(b *Bridge) (bool) {
+	return b.config.ContinueOnIPLookupFailure
+}
+
 func lookupIp(address string) (*http.Response, error) {
 	return client.Get(address)
 }

--- a/registrator.go
+++ b/registrator.go
@@ -37,7 +37,7 @@ var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
 var requireLabel = flag.Bool("require-label", false, "Only register containers which have the SERVICE_REGISTER label, and ignore all others.")
 var ipLookupSource = flag.String("ip-lookup-source", "", "Used to configure IP lookup source. Useful when running locally")
 var ipLookupRetries = flag.Int("ip-lookup-retries", 1, "Used to set how many times it attempts to lookup the IP before exiting (default is 1)")
-var continueOnIpLookupFailure = flag.Bool("continue-on-ip-lookup-failure", false, "When true, registrator will not exit after a lookup failure.")
+var ExitOnIpLookupFailure = flag.Bool("exit-on-ip-lookup-failure", false, "When true, registrator will exit after a lookup failure, if false it will continue trying forever.")
 
 // below IP regex was obtained from http://blog.markhatton.co.uk/2011/03/15/regular-expressions-for-ip-addresses-cidr-ranges-and-hostnames/
 var ipRegEx, _ = regexp.Compile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
@@ -285,7 +285,7 @@ func main() {
 func resyncProcess(b *bridge.Bridge, ipLookupSource string) {
 	if ipLookupSource != "" {
 		temporaryIP, success := bridge.GetIPFromExternalSource()
-		if !success && bridge.ShouldContinueOnIPLookupFailure(b) != true {
+		if !success && bridge.ShouldExitOnIPLookupFailure(b) != true {
 			os.Exit(2)
 		}
 		if success {

--- a/registrator.go
+++ b/registrator.go
@@ -158,7 +158,7 @@ func main() {
 	}
 
 	log.Info("Creating Bridge")
-	bridgeConfig := bridge.Config{
+	b, err := bridge.New(docker, flag.Arg(0), bridge.Config{
 		HostIp:                    selectedIP,
 		Internal:                  *internal,
 		UseIpFromLabel:            *useIpFromLabel,
@@ -169,8 +169,7 @@ func main() {
 		Cleanup:                   *cleanup,
 		RequireLabel:              *requireLabel,
 		ExitOnIPLookupFailure:     *exitOnIpLookupFailure,
-	}
-	b, err := bridge.New(docker, flag.Arg(0), bridgeConfig)
+	})
 	assert(err)
 	log.Info("Bridge Created")
 

--- a/registrator.go
+++ b/registrator.go
@@ -285,7 +285,7 @@ func main() {
 func resyncProcess(b *bridge.Bridge, ipLookupSource string) {
 	if ipLookupSource != "" {
 		temporaryIP, success := bridge.GetIPFromExternalSource()
-		if !success && bridge.ShouldExitOnIPLookupFailure(b) != true {
+		if !success && bridge.ShouldExitOnIPLookupFailure(b) {
 			os.Exit(2)
 		}
 		if success {

--- a/registrator.go
+++ b/registrator.go
@@ -37,7 +37,7 @@ var cleanup = flag.Bool("cleanup", false, "Remove dangling services")
 var requireLabel = flag.Bool("require-label", false, "Only register containers which have the SERVICE_REGISTER label, and ignore all others.")
 var ipLookupSource = flag.String("ip-lookup-source", "", "Used to configure IP lookup source. Useful when running locally")
 var ipLookupRetries = flag.Int("ip-lookup-retries", 1, "Used to set how many times it attempts to lookup the IP before exiting (default is 1)")
-var ExitOnIpLookupFailure = flag.Bool("exit-on-ip-lookup-failure", false, "When true, registrator will exit after a lookup failure, if false it will continue trying forever.")
+var exitOnIpLookupFailure = flag.Bool("exit-on-ip-lookup-failure", false, "When true, registrator will exit after a lookup failure, if false it will continue trying forever.")
 
 // below IP regex was obtained from http://blog.markhatton.co.uk/2011/03/15/regular-expressions-for-ip-addresses-cidr-ranges-and-hostnames/
 var ipRegEx, _ = regexp.Compile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
@@ -168,7 +168,7 @@ func main() {
 		DeregisterCheck:           *deregister,
 		Cleanup:                   *cleanup,
 		RequireLabel:              *requireLabel,
-		ContinueOnIPLookupFailure: *continueOnIpLookupFailure,
+		ExitOnIPLookupFailure:     *exitOnIpLookupFailure,
 	}
 	b, err := bridge.New(docker, flag.Arg(0), bridgeConfig)
 	assert(err)

--- a/registrator.go
+++ b/registrator.go
@@ -285,7 +285,7 @@ func main() {
 func resyncProcess(b *bridge.Bridge, ipLookupSource string) {
 	if ipLookupSource != "" {
 		temporaryIP, success := bridge.GetIPFromExternalSource()
-		if !success && b.config.ContinueOnIPLookupFailure != true {
+		if !success && bridge.ShouldContinueOnIPLookupFailure(b) != true {
 			os.Exit(2)
 		}
 		if success {


### PR DESCRIPTION
Previously Registrator would stop when it's unable to update it's IP address.  This change will make it so it will continue. I've added a `-exit-on-ip-lookup-failure` flag to switch back to the previous behavior.

I made it `exit-on-ip-lookup-failure` rather than `continue-on-ip-lookup-failure` to maintain backwards compatibility since we're using `registrator:latest` and we have no control over when registrator will update.