### PR TITLE
fix unformatted log message

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -229,7 +229,7 @@ func (b *Bridge) newService(port ServicePort, isgroup bool) *Service {
 	metadata, metadataFromPort := serviceMetaData(container.Config, port.ExposedPort)
 
 	ignore := mapDefault(metadata, "ignore", "")
-	log.Info("Checking Ignore: %s", ignore)
+	log.Infof("Checking Ignore: %s", ignore)
 	if ignore != "" {
 		return nil
 	}


### PR DESCRIPTION
This was logging as "Checking Ignore: %s" because it wasn't using log.Infof()